### PR TITLE
githubログインの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 /node_modules
 
 memo.md
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -55,12 +55,16 @@ gem 'bootsnap', require: false
 
 gem 'devise'
 gem 'html2slim'
-gem 'omniauth'
 gem 'slim-rails'
+
+gem 'omniauth'
+gem 'omniauth-github'
+gem 'omniauth-rails_csrf_protection'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     erubis (2.7.0)
     factory_bot (6.4.5)
@@ -115,6 +119,10 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -134,6 +142,7 @@ GEM
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
     json (2.7.1)
+    jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -158,6 +167,9 @@ GEM
     mini_mime (1.1.5)
     minitest (5.21.2)
     msgpack (1.7.2)
+    multi_xml (0.6.0)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -170,10 +182,26 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
     omniauth (2.1.2)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
+    omniauth-github (2.0.1)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -297,6 +325,9 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -318,6 +349,8 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
+    version_gem (1.1.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -346,6 +379,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  dotenv-rails
   factory_bot_rails
   html2slim
   htmlbeautifier
@@ -353,6 +387,8 @@ DEPENDENCIES
   jsbundling-rails
   letter_opener_web
   omniauth
+  omniauth-github
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.0)

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -5,3 +5,4 @@
 @import "users/registration";
 @import "users/login";
 @import "users/error";
+@import "users/shared/links";

--- a/app/assets/stylesheets/users/shared/links.scss
+++ b/app/assets/stylesheets/users/shared/links.scss
@@ -1,0 +1,5 @@
+.github-btn {
+	margin-left: 60px;
+	border-radius: 30px;
+  padding: 10px;
+}

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,31 +2,26 @@
 
 module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    # You should configure your model like this:
-    # devise :omniauthable, omniauth_providers: [:twitter]
+    skip_before_action :verify_authenticity_token, only: :github
 
-    # You should also create an action method in this controller like this:
-    # def twitter
-    # end
+    def github
+      # ユーザー情報を取得
+      @user = User.from_omniauth(request.env['omniauth.auth'])
 
-    # More info at:
-    # https://github.com/heartcombo/devise#omniauth
+      # ユーザーを検索または作成
+      if @user.persisted?
+        @user.skip_confirmation! if @user.respond_to?(:skip_confirmation!)
+        sign_in_and_redirect @user, event: :authentication
+        set_flash_message(:notice, :success, kind: 'Github') if is_navigational_format?
+      else
+        logger.debug 'githubでユーザー検索or作成できませんでした...'
+        session['devise.github_data'] = request.env['omniauth.auth'].except(:extra)
+        redirect_to new_user_registration_url # 登録ページに遷移
+      end
+    end
 
-    # GET|POST /resource/auth/twitter
-    # def passthru
-    #   super
-    # end
-
-    # GET|POST /users/auth/twitter/callback
-    # def failure
-    #   super
-    # end
-
-    # protected
-
-    # The path used when OmniAuth fails
-    # def after_omniauth_failure_path_for(scope)
-    #   super(scope)
-    # end
+    def failure
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,7 +10,7 @@ module Users
 
       # ユーザーを検索または作成
       if @user.persisted?
-        @user.skip_confirmation! if @user.respond_to?(:skip_confirmation!)
+        # @user.skip_confirmation! if @user.respond_to?(:skip_confirmation!)
         sign_in_and_redirect @user, event: :authentication
         set_flash_message(:notice, :success, kind: 'Github') if is_navigational_format?
       else

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -16,7 +16,7 @@ module Users
         # resource.update(confirmed_at: Time .now.utc)       # Welcomeメールを送信した上で、skip_confirmation!と同一処理を行い自動で認証クローズさせる
         # ↓と同じ意味
         resource.uid = User.create_unique_string
-        resource.skip_confirmation!
+        # resource.skip_confirmation!
         resource.save
       end
       flash[:notice] = 'アカウントを作成しました'

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,6 +15,7 @@ module Users
       super do
         # resource.update(confirmed_at: Time .now.utc)       # Welcomeメールを送信した上で、skip_confirmation!と同一処理を行い自動で認証クローズさせる
         # ↓と同じ意味
+        resource.uid = User.create_unique_string
         resource.skip_confirmation!
         resource.save
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,23 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
   
   validates :birthday, presence: true
+
   # ▼uidを必須にした上で、providerカラムの範囲内でuidを一意にする
   validates :uid, presence: true, uniqueness: { scope: :provider }
+
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      logger.debug "authの中身: #{auth.info.inspect}"
+      logger.debug "ユーザー属性: #{user.attributes.inspect}"
+      user.name = "hoge+#{rand(10..99)}"
+      user.email = auth.info.email.presence || "dummy+#{auth.uid}@example.com"
+      user.password = Devise.friendly_token[0, 20]
+      user.birthday = Date.new(1900,1,1) # デフォルトの誕生日（必要に応じて変更）
+      user.phone_number = "090" + rand(10000000..99999999).to_s
+    end
+  end
+
+  def self.create_unique_string
+    SecureRandom.uuid
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       logger.debug "authの中身: #{auth.info.inspect}"
       logger.debug "ユーザー属性: #{user.attributes.inspect}"
-      user.name = "hoge+#{rand(10..99)}"
+      user.name = SecureRandom.alphanumeric(7)
       user.email = auth.info.email.presence || "dummy+#{auth.uid}@example.com"
       user.password = Devise.friendly_token[0, 20]
       user.birthday = Date.new(1900,1,1) # デフォルトの誕生日（必要に応じて変更）

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@
 
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
+        #  :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
+         :recoverable, :rememberable, :validatable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
   
   validates :birthday, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,9 @@
 
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-        #  :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
-         :recoverable, :rememberable, :validatable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
-  
+         :recoverable, :rememberable, :validatable, :lockable,
+         :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
+
   validates :birthday, presence: true
 
   # ▼uidを必須にした上で、providerカラムの範囲内でuidを一意にする
@@ -17,8 +17,8 @@ class User < ApplicationRecord
       user.name = SecureRandom.alphanumeric(7)
       user.email = auth.info.email.presence || "dummy+#{auth.uid}@example.com"
       user.password = Devise.friendly_token[0, 20]
-      user.birthday = Date.new(1900,1,1) # デフォルトの誕生日（必要に応じて変更）
-      user.phone_number = "090" + rand(10000000..99999999).to_s
+      user.birthday = Date.new(1900, 1, 1) # デフォルトの誕生日（必要に応じて変更）
+      user.phone_number = "090#{rand(10_000_000..99_999_999)}"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable
 
   validates :birthday, presence: true
+  # ▼uidを必須にした上で、providerカラムの範囲内でuidを一意にする
+  validates :uid, presence: true, uniqueness: { scope: :provider }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@
 
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable
-
+         :recoverable, :rememberable, :validatable, :confirmable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる
+  
   validates :birthday, presence: true
   # ▼uidを必須にした上で、providerカラムの範囲内でuidを一意にする
   validates :uid, presence: true, uniqueness: { scope: :provider }

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -17,11 +17,8 @@
               = f.telephone_field :phone_number, class: "form-control"
             .form-group
               = f.label :birthday, "生年月日", class: "registration-form__label"
-            / .input-group
-            /   = f.date_select :birthday, { include_blank: true, start_year: Time.now.year, end_year: Time.now.year - 100 }, { class: "form-select", prompt: { day: '日', month: '月', year: '年' } }, { use_month_numbers: true }
             .input-group
               = f.date_select :birthday, { include_blank: true, start_year: Time.now.year, end_year: Time.now.year - 100, prompt: { day: '日', month: '月', year: '年' }, use_month_numbers: true }, { class: "form-select" }
-
             .form-group
               = f.label :password, "パスワード", class: "registration-form__label"
               = f.password_field :password, autocomplete: "new-password", class: "form-control"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -27,7 +27,11 @@
               = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
             .form-group.form-group__submit 
               = f.submit "登録する", class: "btn btn-info w-100 registration-btn"
-              / = render "devise/shared/links"
+              / = render "users/shared/links"
+          = render "users/shared/links"  
+
+
+
 
 
 

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -24,6 +24,6 @@
 
             .form-group.form-group__submit 
               = f.submit "ログイン", class: "btn btn-info w-100 login-btn"
-            / = render "users/shared/links"
+          = render "users/shared/links"
 
 

--- a/app/views/users/shared/_links.html.slim
+++ b/app/views/users/shared/_links.html.slim
@@ -1,19 +1,38 @@
-- if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
-  br
-- if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
-  br
-- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
-  br
-- if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
-  br
-- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
-  br
+/ - if controller_name != 'sessions'
+/   = link_to "Log in", new_session_path(resource_name)
+/   br
+/ - if devise_mapping.registerable? && controller_name != 'registrations'
+/   = link_to "Sign up", new_registration_path(resource_name)
+/   br
+/ - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+/   = link_to "Forgot your password?", new_password_path(resource_name)
+/   br
+/ - if devise_mapping.confirmable? && controller_name != 'confirmations'
+/   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+/   br
+/ - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+/   = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+/   br
+
+
+/ github認証用ボタン
+/ 問題なく動作した
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }
+    = button_to "#{OmniAuth::Utils.camelize(provider)}で登録", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "github-btn btn btn-secondary w-75 mt-3"
     br
+
+/ ▼動いた (CSRF保護が適切に行われ、OmniAuthのセキュリティ推奨に従った認証リクエストが可能になり、Turboの影響を避けることができた為？)
+/ - if devise_mapping.omniauthable?
+/   - resource_class.omniauth_providers.each do |provider|
+/     = button_to "GitHubで登録 #{OmniAuth::Utils.camelize(provider)}", user_github_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-primary w-75 mt-3", style: "margin-left:60px;"
+/     br
+
+/ GETリクエストになるよう修正 (最初は動いたが、ログアウトして再度ボタンを押下すると「Not found. Authentication passthru.」のエラーが出た)
+/ - if devise_mapping.omniauthable?
+/   - resource_class.omniauth_providers.each do |provider|
+/     = link_to "GitHubで登録 #{OmniAuth::Utils.camelize(provider)}", user_github_omniauth_authorize_path, method: :get, data: { turbo: false }, class: "btn btn-primary w-75 mt-3", style: "margin-left:60px;"
+
+
+
+

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,6 +272,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'user:email'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   # dev環境でメール送信を確認
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   root 'home#index'
-  # devise_for :users # Deviseのデフォルトのルーティング
 
   devise_for :users, controllers: {
     registrations: 'users/registrations',
@@ -12,11 +11,4 @@ Rails.application.routes.draw do
     # ▼OAuthのcallback用ルーティング
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
-
-  # Deviseが提供するルートのパスまたは名前をオーバーライドするために使う
-  devise_scope :user do
-    # ▼現状なくても動いてる為コメントアウト
-    # get "users/sign_up", to: "registrations#new"
-    # get "users/sign_in", to: "sessions#new"
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     registrations: 'users/registrations',
-    sessions: 'users/sessions'
+    sessions: 'users/sessions',
+    # ▼OAuthのcallback用ルーティング
+    omniauth_callbacks: 'users/omniauth_callbacks'
   }
 
   # Deviseが提供するルートのパスまたは名前をオーバーライドするために使う

--- a/db/migrate/20240128111126_add_omniauth_to_users.rb
+++ b/db/migrate/20240128111126_add_omniauth_to_users.rb
@@ -2,8 +2,11 @@
 
 class AddOmniauthToUsers < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :provider, :string, null: false, default: ''
-    add_column :users, :uid, :string, null: false, default: ''
+    # change_tableを使用して一括でカラムを追加
+    change_table :users, bulk: true do |t|
+      t.column :provider, :string, null: false, default: ''
+      t.column :uid, :string, null: false, default: ''
+    end
 
     # uidとproviderのカラムの組み合わせに対して一意の制約をつける
     add_index :users, %i[uid provider], unique: true

--- a/db/migrate/20240128111126_add_omniauth_to_users.rb
+++ b/db/migrate/20240128111126_add_omniauth_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddOmniauthToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :provider, :string, null: false, default: ''
+    add_column :users, :uid, :string, null: false, default: ''
+
+    # uidとproviderのカラムの組み合わせに対して一意の制約をつける
+    add_index :users, %i[uid provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_16_013207) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_28_111126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,9 +50,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_16_013207) do
     t.string "avatar_image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", default: "", null: false
+    t.string "uid", default: "", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 


### PR DESCRIPTION
## 課題のリンク

* https://x-clone-web.onrender.com/

## やったこと

* deviseのomniauthableの機能でgithubログインを実装
  * omniauth関連のgemを導入
  * githubでOAuthアプリを作成し、client_id, client_secretsを環境変数を通じて使用してomniauthを使ってアクセスできるよう設定しました
  * Userモデル・Usersテーブルにomniauthで利用するカラム (uid, provider) を追加
    * uidを必須にした上で、providerカラムの範囲内でuidを一意にするようにしました
    * 通常の登録フォームからユーザーを作成する際にランダムなuidを付与するようにしました
  * Userモデルにgithub認証を通じてユーザー作成する際にダミーデータ (name, password, birthday, phone_number) を作成する処理を追加
  * OAuthのコールバック用のルーティング・コントローラを作成


## 動作確認方法

* [新規登録フォーム](https://x-clone-web.onrender.com/users/sign_up)、[ログインフォーム](https://x-clone-web.onrender.com/users/sign_in)にアクセスして、`GitHubで登録`ボタンがある事を確認
* [新規登録フォーム](https://x-clone-web.onrender.com/users/sign_up)にアクセスし、GitHubで登録ボタンを押下してgithub認証画面に遷移して、Authorizeボタンをクリック
* 認証が完了するとログインが完了してホーム画面に遷移する事を確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
  * 本番環境でgithub認証を行うとコールバック処理の際にメール認証で以下のエラーが発生し、Mailgunに登録している1つのアドレス以外現状使用できなかった為、`:confirmable`モジュールを一時的にコメントアウトしております (私のパソコン上では本番環境でgithub認証を用いたログインの動作テストは正常に動く事を確認致しました)
  * 開発環境と本番環境用それぞれのOAuthAppを作成しました (本番環境用のclient_id, client_secretsはRenderのコンソール画面から環境変数として値を設定してあります)
