### PR TITLE
ユーザープロフィールページの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 memo.md
 
 .env
+render-build.sh

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -9,4 +9,5 @@
 @import "users/shared/links";
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "tweets/form";
-@import "tweets/tweet";
+@import "tweets/tweet";@import "tweets/tweet";
+@import "users/profile";

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -29,7 +29,7 @@ body {
 
 .nav-link-top {
 	color: #9b9a9a;
-	font-size: 15px;
+	font-size: 20px;
 	// font-weight: bold;
 	padding-top: 10px
 }

--- a/app/assets/stylesheets/tweets/form.scss
+++ b/app/assets/stylesheets/tweets/form.scss
@@ -10,6 +10,7 @@
 
 .tweet-form__icon-img {
 	height: 40px;
+	width: 40px;
 	border-radius: 30px;
 }
 

--- a/app/assets/stylesheets/users/login.scss
+++ b/app/assets/stylesheets/users/login.scss
@@ -21,11 +21,18 @@
 .login-btn {
   border-radius: 30px;
   padding: 10px;
-  margin: 10px 0;
+  margin: 10px 0 16px 0;
 }
 
 .form-group__submit {
   // 登録ボタン isSIlfirs939ww0s
   // padding: 0 100px;
   margin-top: 30px;
+}
+
+.registration-btn__login-form {
+  border-radius: 30px;
+  padding: 10px;
+  // margin-bottom: 10px;
+  margin-left: 60px;
 }

--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -1,0 +1,103 @@
+// .col-md-6 {
+// 	border: 0.5px solid #9b9a9a;
+// }
+
+.user-profile__container {
+
+}
+
+.user-profile__header {
+
+}
+
+.user-profile__main {
+	
+}
+
+.user-profile__img-area {
+  // background-image: url('../../images/user-prof-bgimg.jpeg'); // `app/javascript/images`内に画像がある場合
+	// background-color: transparent;
+
+  // background-image: url('../../images/tweet-icon.png'); // `app/javascript/images`内に画像がある場合
+  // height: 300px;
+  // background-size: cover;
+	position: relative;
+}
+
+.background-img {
+	width: 104%;
+	height: auto;
+	margin-left: -12px;
+}
+
+.user-profile__icon-area {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-top: 10px;
+}
+
+.user-profile__icon-img {
+
+}
+
+.foreground-img {
+  position: absolute;
+    top: 140px;
+    left: 20px;
+    height: 130px;
+    width: 130px;
+    border-radius: 80px;
+		border: 4px solid black;
+}
+
+.edit-user-btn {
+	border-radius: 30px;
+}
+
+.user-profile__info-area {
+	margin-top: 10px;
+}
+
+.user-profile__name {
+	color: white;
+}
+
+.user-profile__user-name {
+	color: #9b9a9a;
+}
+
+.user-profile__content {
+	color: white;
+}
+
+.user-profile__other-info-area {
+	color: #9b9a9a;
+}
+
+.bi-geo-alt, .bi-link-45deg, .bi-balloon, .bi-calendar4-week {
+	margin-right: 5px;
+}
+
+.bi-link-45deg, .bi-balloon {
+	margin-left: 10px;
+}
+
+.user-website {
+	color: #2B9BF0;
+}
+
+.user-profile__since-area {
+	color: #9b9a9a;
+}
+
+.user-profile__tweet-area {
+	margin-top: 40px;
+}
+
+.nav-link-user-profile {
+	color: #9b9a9a;
+	font-size: 15px;
+	// font-weight: bold;
+	padding-top: 10px
+}

--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -25,8 +25,11 @@
 }
 
 .background-img {
-	width: 104%;
-	height: auto;
+	// width: 104%;
+	// height: auto;
+	// ▼ 一旦固定 レスポンシブの必要があれば修正
+	width: 622px;
+  height: 207px;
 	margin-left: -12px;
 }
 
@@ -43,12 +46,12 @@
 
 .foreground-img {
   position: absolute;
-    top: 140px;
-    left: 20px;
-    height: 130px;
-    width: 130px;
-    border-radius: 80px;
-		border: 4px solid black;
+	top: 140px;
+	left: 20px;
+	height: 130px;
+	width: 130px;
+	border-radius: 80px;
+	border: 4px solid black;
 }
 
 .edit-user-btn {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,18 @@ class ApplicationController < ActionController::Base
 
   def logged_in_user?
     return if user_signed_in?
-
     redirect_to new_user_session_path
+  end
+
+  def set_top_page_tweets
+    # 空の結果セットもページネーションオブジェクトとして扱う
+    @recommended_tweets ||= Tweet.none.page(params[:page])
+    @following_tweets ||= Tweet.none.page(params[:page])
+    if params[:tab] == 'following'
+      followed_user_id = User.find_by(email: 'test-prd02@gmail.com')
+      @following_tweets = Tweet.following_tweets(followed_user_id, params[:page])
+    else
+      @recommended_tweets = Tweet.recommended_tweets(params[:page])
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,17 +7,7 @@ class HomeController < ApplicationController
   def index
     @user = current_user
     @tweet = Tweet.new
-
-    # 空の結果セットもページネーションオブジェクトとして扱う
-    @recommended_tweets ||= Tweet.none.page(params[:page])
-    @following_tweets ||= Tweet.none.page(params[:page])
-    if params[:tab] == 'following'
-      # フォローしているユーザーのツイート一覧
-      followed_user_id = User.find_by(email: 'test-prd02@gmail.com')
-      @following_tweets = Tweet.following_tweets(followed_user_id, params[:page])
-    else
-      # おすすめツイート
-      @recommended_tweets = Tweet.recommended_tweets(params[:page])
-    end
+    # ▼他のコントローラからもトップページを描画するので、共通化した
+    set_top_page_tweets
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,10 +4,21 @@ class UsersController < ApplicationController
   before_action :current_user, only: [:show]
   before_action :set_user, only: %i[show edit]
 
-  def show
-    @my_tweets = Tweet.includes(:user).where(user_id: @user.id).order(created_at: :desc)
-    logger.debug "ログインユーザー: #{@user.inspect}"
-    logger.debug "自分のツイート一覧: #{@my_tweets.inspect}"
+  def show    
+    # ツイートがない時にもtotal_pagesメソッドを実行してエラーが出ないようにする
+    @my_tweets ||= Tweet.none.page(params[:page])
+    @liked_tweets ||= Tweet.none.page(params[:page])
+    @retweeted_tweets ||= Tweet.none.page(params[:page])
+    @commented_tweets ||= Tweet.none.page(params[:page])
+    if params[:tab] == "liked_tweets"
+      @liked_tweets = Tweet.where(content: "いいねした投稿です").page(params[:page]).per(10)
+    elsif params[:tab] == "retweeted_tweets"
+      @retweeted_tweets = Tweet.where(content: "リツイートした投稿です").page(params[:page]).per(10)
+    elsif params[:tab] == "commented_tweets"
+      @commented_tweets = Tweet.where(content: "コメントした投稿です").page(params[:page]).per(10)
+    else
+      @my_tweets = Tweet.my_tweets(@user.id, params[:page])
+    end
   end
 
   def edit; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,18 +4,19 @@ class UsersController < ApplicationController
   before_action :current_user, only: [:show]
   before_action :set_user, only: %i[show edit]
 
-  def show    
+  def show
     # ツイートがない時にもtotal_pagesメソッドを実行してエラーが出ないようにする
     @my_tweets ||= Tweet.none.page(params[:page])
     @liked_tweets ||= Tweet.none.page(params[:page])
     @retweeted_tweets ||= Tweet.none.page(params[:page])
     @commented_tweets ||= Tweet.none.page(params[:page])
-    if params[:tab] == "liked_tweets"
-      @liked_tweets = Tweet.where(content: "いいねした投稿です").page(params[:page]).per(10)
-    elsif params[:tab] == "retweeted_tweets"
-      @retweeted_tweets = Tweet.where(content: "リツイートした投稿です").page(params[:page]).per(10)
-    elsif params[:tab] == "commented_tweets"
-      @commented_tweets = Tweet.where(content: "コメントした投稿です").page(params[:page]).per(10)
+    case params[:tab]
+    when 'liked_tweets'
+      @liked_tweets = Tweet.where(content: 'いいねした投稿です').page(params[:page]).per(10)
+    when 'retweeted_tweets'
+      @retweeted_tweets = Tweet.where(content: 'リツイートした投稿です').page(params[:page]).per(10)
+    when 'commented_tweets'
+      @commented_tweets = Tweet.where(content: 'コメントした投稿です').page(params[:page]).per(10)
     else
       @my_tweets = Tweet.my_tweets(@user.id, params[:page])
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,22 +4,25 @@ class UsersController < ApplicationController
   before_action :current_user, only: [:show]
   before_action :set_user, only: %i[show edit]
 
+  # def show ← rubocopエラーの為リファクタ
+  #   # ツイートがない時にもtotal_pagesメソッドを実行してエラーが出ないようにする
+  #   @my_tweets ||= Tweet.none.page(params[:page])
+  #   @liked_tweets ||= Tweet.none.page(params[:page])
+  #   @retweeted_tweets ||= Tweet.none.page(params[:page])
+  #   @commented_tweets ||= Tweet.none.page(params[:page])
+  #   case params[:tab]
+  #   when 'liked_tweets'
+  #     @liked_tweets = Tweet.where(content: 'いいねした投稿です').page(params[:page]).per(10)
+  #   when 'retweeted_tweets'
+  #     @retweeted_tweets = Tweet.where(content: 'リツイートした投稿です').page(params[:page]).per(10)
+  #   when 'commented_tweets'
+  #     @commented_tweets = Tweet.where(content: 'コメントした投稿です').page(params[:page]).per(10)
+  #   else
+  #     @my_tweets = Tweet.my_tweets(@user.id, params[:page])
+  #   end
+  # end
   def show
-    # ツイートがない時にもtotal_pagesメソッドを実行してエラーが出ないようにする
-    @my_tweets ||= Tweet.none.page(params[:page])
-    @liked_tweets ||= Tweet.none.page(params[:page])
-    @retweeted_tweets ||= Tweet.none.page(params[:page])
-    @commented_tweets ||= Tweet.none.page(params[:page])
-    case params[:tab]
-    when 'liked_tweets'
-      @liked_tweets = Tweet.where(content: 'いいねした投稿です').page(params[:page]).per(10)
-    when 'retweeted_tweets'
-      @retweeted_tweets = Tweet.where(content: 'リツイートした投稿です').page(params[:page]).per(10)
-    when 'commented_tweets'
-      @commented_tweets = Tweet.where(content: 'コメントした投稿です').page(params[:page]).per(10)
-    else
-      @my_tweets = Tweet.my_tweets(@user.id, params[:page])
-    end
+    set_specific_tweets
   end
 
   def edit; end
@@ -42,5 +45,44 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email, :phone_number, :birthday, :website, :place, :profile_image,
                                  :avatar_image, :password, :password_confirmation)
+  end
+
+  # ツイートコレクションの初期設定
+  def set_tweet_collections
+    @my_tweets = Tweet.none.page(params[:page])
+    @liked_tweets = Tweet.none.page(params[:page])
+    @retweeted_tweets = Tweet.none.page(params[:page])
+    @commented_tweets = Tweet.none.page(params[:page])
+  end
+
+  # タブに応じたツイートのセット
+  def set_specific_tweets
+    set_tweet_collections
+    case params[:tab]
+    when 'liked_tweets'
+      fetch_liked_tweets
+    when 'retweeted_tweets'
+      fetch_retweeted_tweets
+    when 'commented_tweets'
+      fetch_commented_tweets
+    else
+      fetch_my_tweets
+    end
+  end
+
+  def fetch_liked_tweets
+    @liked_tweets = Tweet.where(content: 'いいねした投稿です').page(params[:page]).per(10)
+  end
+
+  def fetch_retweeted_tweets
+    @retweeted_tweets = Tweet.where(content: 'リツイートした投稿です').page(params[:page]).per(10)
+  end
+
+  def fetch_commented_tweets
+    @commented_tweets = Tweet.where(content: 'コメントした投稿です').page(params[:page]).per(10)
+  end
+
+  def fetch_my_tweets
+    @my_tweets = Tweet.my_tweets(@user.id, params[:page])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  before_action :current_user, only: [:show]
+  before_action :set_user, only: %i[show edit]
+
+  def show
+    @my_tweets = Tweet.includes(:user).where(user_id: @user.id).order(created_at: :desc)
+    logger.debug "ログインユーザー: #{@user.inspect}"
+    logger.debug "自分のツイート一覧: #{@my_tweets.inspect}"
+  end
+
+  def edit; end
+
+  def update
+    # if @user.update(user_params)
+    #   redirect_to user_path(@user)
+    # else
+    #   # ▼ 何やってるのか調べる ito_junichi
+    #   render :edit, status: :unprocessable_entity
+    # end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :phone_number, :birthday, :website, :place, :profile_image,
+                                 :avatar_image, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,23 +4,6 @@ class UsersController < ApplicationController
   before_action :current_user, only: [:show]
   before_action :set_user, only: %i[show edit]
 
-  # def show ← rubocopエラーの為リファクタ
-  #   # ツイートがない時にもtotal_pagesメソッドを実行してエラーが出ないようにする
-  #   @my_tweets ||= Tweet.none.page(params[:page])
-  #   @liked_tweets ||= Tweet.none.page(params[:page])
-  #   @retweeted_tweets ||= Tweet.none.page(params[:page])
-  #   @commented_tweets ||= Tweet.none.page(params[:page])
-  #   case params[:tab]
-  #   when 'liked_tweets'
-  #     @liked_tweets = Tweet.where(content: 'いいねした投稿です').page(params[:page]).per(10)
-  #   when 'retweeted_tweets'
-  #     @retweeted_tweets = Tweet.where(content: 'リツイートした投稿です').page(params[:page]).per(10)
-  #   when 'commented_tweets'
-  #     @commented_tweets = Tweet.where(content: 'コメントした投稿です').page(params[:page]).per(10)
-  #   else
-  #     @my_tweets = Tweet.my_tweets(@user.id, params[:page])
-  #   end
-  # end
   def show
     set_specific_tweets
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -20,4 +20,13 @@ class Tweet < ApplicationRecord
       .page(page)
       .per(10)
   }
+
+  # 自分のツイート
+  scope :my_tweets, ->(user_id, page) {
+    where(user_id: user_id)
+    .includes(:user)
+    .order(created_at: :desc)
+    .page(page)
+    .per(10)
+  }
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -29,5 +29,13 @@ class Tweet < ApplicationRecord
       .page(page)
       .per(10)
   }
-  }
+
+  # いいねしたツイート
+  # scope :liked_tweets, lambda { |user_id, _tweet_id, page|
+  #   where(user_id:)
+  #     .includes(:user)
+  #     .order(created_at: :desc)
+  #     .page(page)
+  #     .per(10)
+  # }
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -22,11 +22,12 @@ class Tweet < ApplicationRecord
   }
 
   # 自分のツイート
-  scope :my_tweets, ->(user_id, page) {
-    where(user_id: user_id)
-    .includes(:user)
-    .order(created_at: :desc)
-    .page(page)
-    .per(10)
+  scope :my_tweets, lambda { |user_id, page|
+    where(user_id:)
+      .includes(:user)
+      .order(created_at: :desc)
+      .page(page)
+      .per(10)
+  }
   }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@
 
 class User < ApplicationRecord
   has_many :tweets, dependent: :destroy
+  has_one_attached :avatar_image
+  has_one_attached :profile_image
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :lockable,
          :timeoutable, :trackable, :omniauthable, omniauth_providers: %i[github] # ← githubでのOAuthに対応させる

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -26,26 +26,3 @@
           / フォロー中ツイート
           = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
           = paginate @following_tweets
-
-
-
-    / .col-md-6
-    /   / タブ (修正前)
-    /   ul.nav.nav-tabs
-    /     li.nav-item.nav-tab__recommended
-    /       a.nav-link.nav-link-top.active href="#recommended" data-bs-toggle="tab" おすすめ
-    /     li.nav-item.nav-tab__following
-    /       a.nav-link.nav-link-top href="#following" data-bs-toggle="tab" フォロー中
-    /   .tab-content
-    /     #recommended.tab-pane.active
-    /       / ツイートフォーム
-    /       = render "tweets/form"
-    /       / おすすめツイート
-    /       = render partial: "tweets/tweet", collection: @recommended_tweets, as: :tweet
-    /       = paginate @recommended_tweets
-    /     #following.tab-pane
-    /       / ツイートフォーム
-    /       = render "tweets/form"
-    /       / フォロー中ツイート
-    /       = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
-    /       = paginate @following_tweets

--- a/app/views/tweets/_form.html.slim
+++ b/app/views/tweets/_form.html.slim
@@ -1,6 +1,10 @@
 = form_with(model: @tweet, class: "tweet-form__container", local: true) do |f|
   .tweet-form__main
-    = image_tag 'tweet-icon.png', class: 'tweet-form__icon-img'  
+    = link_to user_path(current_user), class: "nav-link nav-link__icon" do 
+      - if current_user.avatar_image.attached?
+        = image_tag current_user.avatar_image, class: 'tweet-form__icon-img'
+      - else 
+        = image_tag 'tweet-icon.png', class: 'tweet-form__icon-img'
     = f.text_area :content, class: "tweet-form__textarea", placeholder: "今どうしてる？"
   .tweet-form__footer 
     .tweet-form_img-up-area data-controller="image-upload"

--- a/app/views/tweets/_sidebar.html.slim
+++ b/app/views/tweets/_sidebar.html.slim
@@ -36,7 +36,7 @@ nav
 				| リスト
 	ul.nav.flex-column 
 		li.nav-item 
-			= link_to user_path(@user), class: "nav-link nav-link__icon" do 
+			= link_to user_path(@current_user), class: "nav-link nav-link__icon" do 
 				i.bi.bi-person
 				| プロフィール
 	= link_to "ポストする", root_path, class: "post-btn btn btn-info"

--- a/app/views/tweets/_sidebar.html.slim
+++ b/app/views/tweets/_sidebar.html.slim
@@ -6,7 +6,7 @@ nav
 				|
 	ul.nav.flex-column
 		li.nav-item
-			a.nav-link.nav-link__icon href="#"
+			= link_to root_path, class: "nav-link nav-link__icon" do 
 				i.bi.bi-house-door-fill
 				| ホーム
 	ul.nav.flex-column
@@ -34,9 +34,9 @@ nav
 			a.nav-link.nav-link__icon href="#"
 				i.bi.bi-file-earmark-text
 				| リスト
-	ul.nav.flex-column
-		li.nav-item
-			a.nav-link.nav-link__icon href="#"
+	ul.nav.flex-column 
+		li.nav-item 
+			= link_to user_path(@user), class: "nav-link nav-link__icon" do 
 				i.bi.bi-person
 				| プロフィール
 	= link_to "ポストする", root_path, class: "post-btn btn btn-info"

--- a/app/views/tweets/_tweet.html.slim
+++ b/app/views/tweets/_tweet.html.slim
@@ -1,23 +1,9 @@
-/ .tweet__container 
-/   .tweet-icon__container
-/     - if tweet.user.avatar_image.attached?
-/       = image_tag(tweet.user.avatar_image, class: "tweet-icon__img")
-/     - else
-/       = image_tag('tweet-icon.png', class: 'tweet-icon__img')
-/   .tweet-info__container 
-/     .tweet-name 
-/       p = tweet.user.name 
-/     .tweet-content 
-/       p = tweet.content 
-/     .tweet__action-area
-/       i.bi.bi-chat.tweet__action-icon
-/       i.bi.bi-repeat.tweet__action-icon
-/       i.bi.bi-heart.tweet__action-icon
-/       i.bi.bi-bookmark.tweet__action-icon
-
 .tweet__container 
   .tweet-icon__container
-    = image_tag 'tweet-icon.png', class: 'tweet-icon__img'
+    - if tweet.user.avatar_image.attached?
+      = image_tag(tweet.user.avatar_image, class: "tweet-icon__img")
+    - else
+      = image_tag('user-icon.png', class: 'tweet-icon__img')
   .tweet-info__container 
     .tweet-name 
       p = tweet.user.name 
@@ -28,5 +14,3 @@
       i.bi.bi-repeat.tweet__action-icon
       i.bi.bi-heart.tweet__action-icon
       i.bi.bi-bookmark.tweet__action-icon
-
-

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -24,6 +24,7 @@
 
             .form-group.form-group__submit 
               = f.submit "ログイン", class: "btn btn-info w-100 login-btn"
+          = link_to "新規登録はこちら", new_user_registration_path, class: 'registration-btn__login-form btn btn-primary w-75' 
           = render "users/shared/links"
 
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -37,25 +37,25 @@
 								| 2019年1月からTwitterを利用しています
 						.user-profile__tweet-area
 							ul.nav.nav-tabs
-								li.nav-item.nav-tab__my-tweet
-									a.nav-link.nav-link-user-profile.active href="#my-tweet" data-bs-toggle="tab" ポスト
-								li.nav-item.nav-tab__like
-									a.nav-link.nav-link-user-profile href="#like" data-bs-toggle="tab" いいね
-								li.nav-item.nav-tab__retweet
-									a.nav-link.nav-link-user-profile href="#retweet" data-bs-toggle="tab" リツイート
-								li.nav-item.nav-tab__comment
-									a.nav-link.nav-link-user-profile href="#comment" data-bs-toggle="tab" コメント
+								li.nav-item.nav-tab__my_tweets
+									= link_to 'ポスト', user_path(@user, tab: 'my_tweets'), class: "nav-link nav-link-top#{' active' if params[:tab].blank? || params[:tab] == 'my_tweets'}"
+								li.nav-item.nav-tab__liked_tweets
+									= link_to 'いいね', user_path(@user, tab: 'liked_tweets'), class: "nav-link nav-link-top#{' active' if params[:tab] == 'liked_tweets'}"
+								li.nav-item.nav-tab__retweeted_tweets
+									= link_to 'リツイート', user_path(@user, tab: 'retweeted_tweets'), class: "nav-link nav-link-top#{' active' if params[:tab] == 'retweeted_tweets'}"
+								li.nav-item.nav-tab__commented_tweets
+									= link_to 'コメント', user_path(@user, tab: 'commented_tweets'), class: "nav-link nav-link-top#{' active' if params[:tab] == 'commented_tweets'}"
 							.tab-content
-								#my-tweet.tab-pane.active
+								#my_tweets.tab-pane class=(params[:tab].blank? || params[:tab] == 'my_tweets' ? 'active' : nil)
 									= render partial: "tweets/tweet", collection: @my_tweets, as: :tweet
-									/ = paginate @my_tweets
-								#like.tab-pane
-									/ = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
-									/ = paginate @following_tweets
-								#retweet.tab-pane
-									/ = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
-									/ = paginate @following_tweets
-								#comment.tab-pane
-									/ = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
-									/ = paginate @following_tweets
+									= paginate @my_tweets
+								#liked_tweets.tab-pane class=(params[:tab] == "liked_tweets" ? "active" : nil)
+									= render partial: "tweets/tweet", collection: @liked_tweets, as: :tweet  
+									= paginate @liked_tweets
+								#retweeted_tweets.tab-pane class=(params[:tab] == "retweeted_tweets" ? "active" : nil)
+									= render partial: "tweets/tweet", collection: @retweeted_tweets, as: :tweet  
+									= paginate @retweeted_tweets
+								#commented_tweets.tab-pane class=(params[:tab] == "commented_tweets" ? "active" : nil)
+									= render partial: "tweets/tweet", collection: @commented_tweets, as: :tweet  
+									= paginate @commented_tweets
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -14,10 +14,10 @@
 					/ ヘッダーの名前のエリア
 					.user-profile__main
 						.user-profile__img-area
-							= @user.profile_image.attached? ? image_tag(@user.profile_image, class: "background-img") : "画像が存在しません"
+							= @user.profile_image.attached? ? image_tag(@user.profile_image, class: "background-img") : image_tag('user-prof-bgimg.jpeg', class: "background-img")
 							.user-profile__icon-area 
 								.user-profile__icon-img
-									= @user.avatar_image.attached? ? image_tag(@user.avatar_image, class: "foreground-img") : "画像が存在しません"
+									= @user.avatar_image.attached? ? image_tag(@user.avatar_image, class: "foreground-img") : image_tag('user-icon.png', class: "foreground-img")
 								.user-profile__edit-btn
 									= link_to "プロフィールを編集", edit_user_path(@user), class: 'btn btn-outline-light edit-user-btn' 
 						.user-profile__info-area

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,0 +1,61 @@
+= render "layouts/navigation"
+
+= render "/users/shared/notice"
+.container.px-4.px-lg-5
+  .row
+    .col-md-3
+      = render "tweets/sidebar"
+    .col-md-6
+			- if user_signed_in?
+				/ プロフィールエリア
+				h3.user-profile__name ← ゆう
+				.user-profile__container
+					.user-profile__header
+					/ ヘッダーの名前のエリア
+					.user-profile__main
+						.user-profile__img-area
+							= @user.profile_image.attached? ? image_tag(@user.profile_image, class: "background-img") : "画像が存在しません"
+							.user-profile__icon-area 
+								.user-profile__icon-img
+									= @user.avatar_image.attached? ? image_tag(@user.avatar_image, class: "foreground-img") : "画像が存在しません"
+								.user-profile__edit-btn
+									= link_to "プロフィールを編集", edit_user_path(@user), class: 'btn btn-outline-light edit-user-btn' 
+						.user-profile__info-area
+							h3.user-profile__name = @user.name
+							p.user-profile__user-name @yuuu1654
+							span.user-profile__content = @user.introduction
+							.user-profile__other-info-area
+								i.bi.bi-geo-alt
+								= @user.place
+								i.bi.bi-link-45deg
+								span.user-website = @user.website
+								i.bi.bi-balloon
+								| 誕生日 : 
+								= @user.birthday.strftime('%Y年%m月%d日')
+							.user-profile__since-area
+								i.bi.bi-calendar4-week
+								| 2019年1月からTwitterを利用しています
+						.user-profile__tweet-area
+							ul.nav.nav-tabs
+								li.nav-item.nav-tab__my-tweet
+									a.nav-link.nav-link-user-profile.active href="#my-tweet" data-bs-toggle="tab" ポスト
+								li.nav-item.nav-tab__like
+									a.nav-link.nav-link-user-profile href="#like" data-bs-toggle="tab" いいね
+								li.nav-item.nav-tab__retweet
+									a.nav-link.nav-link-user-profile href="#retweet" data-bs-toggle="tab" リツイート
+								li.nav-item.nav-tab__comment
+									a.nav-link.nav-link-user-profile href="#comment" data-bs-toggle="tab" コメント
+							.tab-content
+								#my-tweet.tab-pane.active
+									= render partial: "tweets/tweet", collection: @my_tweets, as: :tweet
+									/ = paginate @my_tweets
+								#like.tab-pane
+									/ = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
+									/ = paginate @following_tweets
+								#retweet.tab-pane
+									/ = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
+									/ = paginate @following_tweets
+								#comment.tab-pane
+									/ = render partial: "tweets/tweet", collection: @following_tweets, as: :tweet  
+									/ = paginate @following_tweets
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,10 @@ Rails.application.routes.draw do
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
 
-  post '/tweets', to: 'tweets#create'
-
   # get '/users/show', to: 'users#show'
   # get '/users/:id', to: 'users#show' ← なぜかヘルパーURLが生成されない？ user_path(@user)
   # resources :users, only: [:show, :edit]
   resources :users
+
+  post '/tweets', to: 'tweets#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,9 @@ Rails.application.routes.draw do
   }
 
   post '/tweets', to: 'tweets#create'
+
+  # get '/users/show', to: 'users#show'
+  # get '/users/:id', to: 'users#show' ← なぜかヘルパーURLが生成されない？ user_path(@user)
+  # resources :users, only: [:show, :edit]
+  resources :users
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -108,15 +108,14 @@
 # following.each { |followed| user.follow(followed) }
 # followers.each { |follower| follower.follow(user) }
 
-
 # いいね・リツイート・コメントしたツイートの確認用データ
-test_user = User.find_by(email: "test-prd01@gmail.com")
-3.times do |_n|
+test_user = User.find_by(email: 'test-prd01@gmail.com')
+10.times do |_n|
   user_id = test_user.id
-  sample_sentences = [
-    'いいねした投稿です',
-    'リツイートした投稿です',
-    'コメントした投稿です'
+  sample_sentences = %w[
+    いいねした投稿です
+    リツイートした投稿です
+    コメントした投稿です
   ]
   # サンプルツイートからランダムに一つ選ぶ
   content = sample_sentences.sample

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -110,16 +110,16 @@
 
 # いいね・リツイート・コメントしたツイートの確認用データ
 # test_user = User.find_by(email: 'test-prd01@gmail.com')
-test_user = User.find_by(id: 20)
-10.times do |_n|
-  user_id = test_user.id
-  sample_sentences = %w[
-    いいねした投稿です
-    リツイートした投稿です
-    コメントした投稿です
-  ]
-  # サンプルツイートからランダムに一つ選ぶ
-  content = sample_sentences.sample
-  Tweet.create!(user_id:,
-                content:)
-end
+# test_user = User.find_by(id: 20)
+# 10.times do |_n|
+#   user_id = test_user.id
+#   sample_sentences = %w[
+#     いいねした投稿です
+#     リツイートした投稿です
+#     コメントした投稿です
+#   ]
+#   # サンプルツイートからランダムに一つ選ぶ
+#   content = sample_sentences.sample
+#   Tweet.create!(user_id:,
+#                 content:)
+# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,101 +4,101 @@
 # ユーザー作成
 
 # テスト用ユーザー1 (自分)
-User.create!(
-  name: '本番テスト用1',
-  email: 'test-prd01@gmail.com',
-  password: 'testprd01',
-  birthday: Date.new(2000, 1, 1),
-  phone_number: "090#{rand(10_000_000..99_999_999)}",
-  uid: User.create_unique_string
-)
+# User.create!(
+#   name: '本番テスト用1',
+#   email: 'test-prd01@gmail.com',
+#   password: 'testprd01',
+#   birthday: Date.new(2000, 1, 1),
+#   phone_number: "090#{rand(10_000_000..99_999_999)}",
+#   uid: User.create_unique_string
+# )
 
-# テスト用ユーザー2 (フォロー対象ユーザー)
-user2 = User.create!(
-  name: '本番テスト用2',
-  email: 'test-prd02@gmail.com',
-  password: 'testprd02',
-  birthday: Date.new(2000, 1, 1),
-  phone_number: "090#{rand(10_000_000..99_999_999)}",
-  uid: User.create_unique_string
-)
+# # テスト用ユーザー2 (フォロー対象ユーザー)
+# user2 = User.create!(
+#   name: '本番テスト用2',
+#   email: 'test-prd02@gmail.com',
+#   password: 'testprd02',
+#   birthday: Date.new(2000, 1, 1),
+#   phone_number: "090#{rand(10_000_000..99_999_999)}",
+#   uid: User.create_unique_string
+# )
 
-# テスト用ユーザー3 (フォローしていないユーザー)
-user3 = User.create!(
-  name: '本番テスト用3',
-  email: 'test-prd03@gmail.com',
-  password: 'testprd03',
-  birthday: Date.new(2000, 1, 1),
-  phone_number: "090#{rand(10_000_000..99_999_999)}",
-  uid: User.create_unique_string
-)
+# # テスト用ユーザー3 (フォローしていないユーザー)
+# user3 = User.create!(
+#   name: '本番テスト用3',
+#   email: 'test-prd03@gmail.com',
+#   password: 'testprd03',
+#   birthday: Date.new(2000, 1, 1),
+#   phone_number: "090#{rand(10_000_000..99_999_999)}",
+#   uid: User.create_unique_string
+# )
 
-# 10.times do |n|
-#   name  = "user#{n+10}"
-#   email = "example-#{n+10}@gmail.com"
-# 	password = Devise.friendly_token[0, 20]
-# 	birthday = Date.new(2000, 1, 1)
-# 	phone_number = "090#{rand(10_000_000..99_999_999)}"
-# 	uid = User.create_unique_string
-#   User.create!(name: name,
-#               email: email,
-#               password: password,
-#               birthday: birthday,
-#               phone_number: phone_number,
-# 							uid: uid)
+# # 10.times do |n|
+# #   name  = "user#{n+10}"
+# #   email = "example-#{n+10}@gmail.com"
+# # 	password = Devise.friendly_token[0, 20]
+# # 	birthday = Date.new(2000, 1, 1)
+# # 	phone_number = "090#{rand(10_000_000..99_999_999)}"
+# # 	uid = User.create_unique_string
+# #   User.create!(name: name,
+# #               email: email,
+# #               password: password,
+# #               birthday: birthday,
+# #               phone_number: phone_number,
+# # 							uid: uid)
+# # end
+
+# # ツイート作成 (フォローしてない人)
+# 10.times do |_n|
+#   user_id = user3.id
+#   sample_sentences = [
+#     '今日は良い天気ですね。',
+#     '最近読んだ本が面白かった。',
+#     '明日は友達と映画を見に行きます。',
+#     '新しいレストランを試してみたい。',
+#     '週末は家でゆっくり過ごしたい。',
+#     '今日学んだことを忘れないようにしよう。',
+#     '音楽を聴きながら勉強するのが好き。',
+#     '旅行の計画を立て始めた。',
+#     '美味しいコーヒーの淹れ方を学びたい。',
+#     '運動することで気分が良くなった。',
+#     'サッカーと野球どっち派？もしかして卓球派？'
+#   ]
+#   # サンプルツイートからランダムに一つ選ぶ
+#   content = sample_sentences.sample
+#   Tweet.create!(user_id:,
+#                 content:)
 # end
 
-# ツイート作成 (フォローしてない人)
-10.times do |_n|
-  user_id = user3.id
-  sample_sentences = [
-    '今日は良い天気ですね。',
-    '最近読んだ本が面白かった。',
-    '明日は友達と映画を見に行きます。',
-    '新しいレストランを試してみたい。',
-    '週末は家でゆっくり過ごしたい。',
-    '今日学んだことを忘れないようにしよう。',
-    '音楽を聴きながら勉強するのが好き。',
-    '旅行の計画を立て始めた。',
-    '美味しいコーヒーの淹れ方を学びたい。',
-    '運動することで気分が良くなった。',
-    'サッカーと野球どっち派？もしかして卓球派？'
-  ]
-  # サンプルツイートからランダムに一つ選ぶ
-  content = sample_sentences.sample
-  Tweet.create!(user_id:,
-                content:)
-end
+# # ツイート作成 (フォローしてる人)
+# 10.times do |_n|
+#   user_id = user2.id
+#   sample_sentences = [
+#     '今日は良い天気ですね。',
+#     '最近読んだ本が面白かった。',
+#     '明日は友達と映画を見に行きます。',
+#     '新しいレストランを試してみたい。',
+#     '週末は家でゆっくり過ごしたい。',
+#     '今日学んだことを忘れないようにしよう。',
+#     '音楽を聴きながら勉強するのが好き。',
+#     '旅行の計画を立て始めた。',
+#     '美味しいコーヒーの淹れ方を学びたい。',
+#     '運動することで気分が良くなった。',
+#     'サッカーと野球どっち派？もしかして卓球派？'
+#   ]
+#   # サンプルツイートからランダムに一つ選ぶ
+#   content = sample_sentences.sample
+#   Tweet.create!(user_id:,
+#                 content:)
+# end
 
-# ツイート作成 (フォローしてる人)
-10.times do |_n|
-  user_id = user2.id
-  sample_sentences = [
-    '今日は良い天気ですね。',
-    '最近読んだ本が面白かった。',
-    '明日は友達と映画を見に行きます。',
-    '新しいレストランを試してみたい。',
-    '週末は家でゆっくり過ごしたい。',
-    '今日学んだことを忘れないようにしよう。',
-    '音楽を聴きながら勉強するのが好き。',
-    '旅行の計画を立て始めた。',
-    '美味しいコーヒーの淹れ方を学びたい。',
-    '運動することで気分が良くなった。',
-    'サッカーと野球どっち派？もしかして卓球派？'
-  ]
-  # サンプルツイートからランダムに一つ選ぶ
-  content = sample_sentences.sample
-  Tweet.create!(user_id:,
-                content:)
-end
+# # ユーザー
+# User.all
+# test_user = User.find_by(email: 'test-prd01@gmail.com')
+# followed_user = User.find_by(email: 'test-prd02@gmail.com')
 
-# ユーザー
-User.all
-test_user = User.find_by(email: 'test-prd01@gmail.com')
-followed_user = User.find_by(email: 'test-prd02@gmail.com')
-
-# フォロー関係作成
-Follow.find_or_create_by(follower_id: test_user.id, followed_id: followed_user.id)
+# # フォロー関係作成
+# Follow.find_or_create_by(follower_id: test_user.id, followed_id: followed_user.id)
 
 # フォロー機能を作る時に実装
 # users = User.all
@@ -107,3 +107,19 @@ Follow.find_or_create_by(follower_id: test_user.id, followed_id: followed_user.i
 # followers = users[3..40]
 # following.each { |followed| user.follow(followed) }
 # followers.each { |follower| follower.follow(user) }
+
+
+# いいね・リツイート・コメントしたツイートの確認用データ
+test_user = User.find_by(email: "test-prd01@gmail.com")
+3.times do |_n|
+  user_id = test_user.id
+  sample_sentences = [
+    'いいねした投稿です',
+    'リツイートした投稿です',
+    'コメントした投稿です'
+  ]
+  # サンプルツイートからランダムに一つ選ぶ
+  content = sample_sentences.sample
+  Tweet.create!(user_id:,
+                content:)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,7 +109,8 @@
 # followers.each { |follower| follower.follow(user) }
 
 # いいね・リツイート・コメントしたツイートの確認用データ
-test_user = User.find_by(email: 'test-prd01@gmail.com')
+# test_user = User.find_by(email: 'test-prd01@gmail.com')
+test_user = User.find_by(id: 20)
 10.times do |_n|
   user_id = test_user.id
   sample_sentences = %w[

--- a/lib/tasks/attach_user_images.rake
+++ b/lib/tasks/attach_user_images.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+namespace :user do
+  desc 'Attach images to user'
+  task attach_images: :environment do
+    # 実行コマンド :
+    test_user = User.find_by(email: 'test-prd01@gmail.com')
+    user_id = test_user.id
+    avatar_path = Rails.root.join('app/assets/images/user-icon.png')
+    profile_path = Rails.root.join('app/assets/images/user-prof-bgimg.jpeg')
+
+    exit unless user_id && avatar_path && profile_path
+
+    user = User.find_by(id: user_id)
+    unless user
+      puts "ユーザーが存在しません...: #{user_id}"
+      exit
+    end
+
+    # Attach avatar_image
+    if File.exist?(avatar_path)
+      user.avatar_image.attach(io: File.open(avatar_path), filename: 'user-icon.png')
+      puts 'アイコン画像のデータを紐付けました'
+    else
+      puts 'アイコン画像のデータが存在しません'
+    end
+
+    # Attach profile_image
+    if File.exist?(profile_path)
+      user.profile_image.attach(io: File.open(profile_path), filename: 'user-prof-bgimg.jpeg')
+      puts 'プロフィール画像のデータを紐付けました'
+    else
+      puts 'プロフィール画像のデータが存在しません'
+    end
+  end
+end


### PR DESCRIPTION
## 課題のリンク

* https://x-clone-web.onrender.com/

## やったこと

* ユーザーのプロフィールページを作成
  * トップページのサイドバー プロフィールアイコン・投稿フォームの画像アイコンよりユーザープロフィールページに遷移できるようにしました
  * 名前・アイコン/ヘッダー画像・自己紹介・場所・ウェブサイト・生年月日をユーザーのデータを参照するようにしました
  * 自分のツイート・いいねしたツイート・リツイートしたツイート・コメントしたツイートのseedデータを作成
  * 自分のツイート・いいねしたツイート・リツイートしたツイート・コメントしたツイートを、それぞれ一覧表示して、トップページ同様以下の2点の機能を導入
    * タブで表示切り替えができる
    * ページネーション導入 (1ページあたり10件表示)

## 動作確認方法

* [トップページ](https://x-clone-web.onrender.com/)のサイドバー、プロフィールアイコンよりユーザープロフィールページに遷移
* 以下のテスト用アカウントでログイン
  * email : `test-prd01@gmail.com`
  * password : `testprd01`
* 名前・アイコン/ヘッダー画像・自己紹介・場所・ウェブサイト・生年月日が表示されていることを確認
* 自分のツイート・いいねしたツイート・リツイートしたツイート・コメントしたツイートがタブを切り替えてそれぞれ表示されていることを確認
* ページネーションが実装されていることを確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
  *  初回push時はciのdangerエラーが出ていなかったのですが、追加修正push時に前回同様のdangerエラーが出ています
