### PR TITLE
プロフィール編集画面 作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,9 @@ gem 'bootsnap', require: false
 # gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem 'image_processing', '~> 1.2'
-# gem 'active_storage_validations'
+gem 'active_storage_validations'
 gem 'aws-sdk-s3', require: false
+gem 'image_processing', '~> 1.2'
 
 gem 'devise'
 gem 'html2slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (1.1.4)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -410,6 +415,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_storage_validations
   aws-sdk-s3
   bootsnap
   capybara

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -9,5 +9,6 @@
 @import "users/shared/links";
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "tweets/form";
-@import "tweets/tweet";@import "tweets/tweet";
+@import "tweets/tweet";
 @import "users/profile";
+@import "users/edit";

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -27,6 +27,15 @@ body {
 	padding-top: 10px
 }
 
+// todo: ナブhover/active時のcss修正
+// .nav-link.active {
+// 	color: white;
+// 	font-size: 25px;
+// 	font-weight: bold;
+// 	padding-top: 10px;
+// 	border-bottom: 1px solid #2B9BF0;
+// }
+
 .nav-link-top {
 	color: #9b9a9a;
 	font-size: 20px;

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -1,0 +1,46 @@
+// モーダルの背景色　#242D35
+
+.user-edit-form__container {
+  background-color: #201f1f;
+}
+
+.user-edit-form__title {
+  color: white;
+  font-weight: bold;
+}
+
+.user-edit-form {
+  padding: 0 60px;
+}
+
+.user-edit-form__label {
+  color: white;
+  margin-top: 20px;
+}
+
+.user-edit-btn {
+  border-radius: 30px;
+  padding: 10px;
+}
+
+.form-group__submit {
+  // 登録ボタン isSIlfirs939ww0s
+  // padding: 0 100px;
+  margin-top: 30px;
+}
+
+.user-edit-form__profile_img {
+	// height: 40px;
+	// width: 40px;
+	// border-radius: 30px;
+  width: 350px;
+  margin-top: 50px;
+}
+
+.user-edit-form__avatar_img {
+  height: 130px;
+  width: 130px;
+  border-radius: 80px;
+  border: 4px solid black;
+  margin-top: 30px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   def logged_in_user?
     return if user_signed_in?
+
     redirect_to new_user_session_path
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  before_action :current_user, only: [:index]
   before_action :logged_in_user?, only: [:index]
 
   def index
-    @user = current_user
-    @tweet = Tweet.new
+    @tweet = Tweet.new # ツイートフォーム表示させる為
     # ▼他のコントローラからもトップページを描画するので、共通化した
     set_top_page_tweets
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :current_user, only: [:show]
   before_action :set_user, only: %i[show edit update]
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,8 +31,10 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :phone_number, :introduction, :birthday, :website, :place, :profile_image,
-                                 :avatar_image, :password, :password_confirmation).tap do |user_params|
+    params.require(:user).permit(
+      :name, :email, :phone_number, :introduction, :birthday, :website,
+      :place, :profile_image, :avatar_image, :password, :password_confirmation
+    ).tap do |user_params|
       # 更新時にパスワード・パスワード確認が空なら更新対象から除外する
       if user_params[:password].blank? && user_params[:password_confirmation].blank?
         user_params.delete(:password)

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -5,7 +5,7 @@
 .container.px-4.px-lg-5
   .row
     .col-md-3
-      = render "tweets/sidebar", user: @user
+      = render "tweets/sidebar", user: current_user
     .col-md-6
       / タブ
       ul.nav.nav-tabs

--- a/app/views/layouts/_navigation.html.slim
+++ b/app/views/layouts/_navigation.html.slim
@@ -7,7 +7,7 @@ nav.navbar.navbar-expand-lg.navbar-dark.bg-dark
       / ▼右端に寄せる
       .navbar-nav.ms-auto 
         - if user_signed_in?
-          h4.name_text = @current_user.name
+          h4.name_text = current_user.name
           = link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-secondary"
         - else
           = link_to "ログイン", new_user_session_path, class: "btn btn-outline-primary", style: "margin-right: 10px;"

--- a/app/views/tweets/_sidebar.html.slim
+++ b/app/views/tweets/_sidebar.html.slim
@@ -36,7 +36,7 @@ nav
 				| リスト
 	ul.nav.flex-column 
 		li.nav-item 
-			= link_to user_path(@current_user), class: "nav-link nav-link__icon" do 
+			= link_to user_path(current_user), class: "nav-link nav-link__icon" do 
 				i.bi.bi-person
 				| プロフィール
 	= link_to "ポストする", root_path, class: "post-btn btn btn-info"

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,0 +1,55 @@
+.container.mt-5
+  .row.justify-content-center
+    .col-md-5
+      .card.shadow.user-edit-form__container
+        .card-body
+          h2.text-center.mb-4.user-edit-form__title アカウントを編集
+          = form_with(model: @user, url: user_path(@user), class: "user-edit-form", local: true) do |f|
+            - if @user.errors.any?
+              .alert.alert-danger
+                ul
+                  - @user.errors.full_messages.each do |msg|
+                    li = msg
+            .form-group
+              = f.label :name, "ユーザー名", class: "user-edit-form__label"
+              = f.text_field :name, class: "form-control", autocomplete: "name"
+            .form-group
+              = f.label :email, "メールアドレス", class: "user-edit-form__label"
+              = f.email_field :email, class: "form-control", autocomplete: "email"
+            .form-group
+              = f.label :phone_number, "電話番号", class: "user-edit-form__label"
+              = f.telephone_field :phone_number, class: "form-control"
+            .form-group
+              = f.label :introduction, "自己紹介", class: "user-edit-form__label"
+              = f.text_field :introduction, class: "form-control"
+            .form-group
+              = f.label :place, "場所", class: "user-edit-form__label"
+              = f.text_field :place, class: "form-control"
+            .form-group
+              = f.label :website, "ウェブサイト", class: "user-edit-form__label"
+              = f.text_field :website, class: "form-control"
+            .form-group
+              = f.label :birthday, "生年月日", class: "user-edit-form__label"
+            .input-group
+              = f.date_select :birthday, { include_blank: true, start_year: Time.now.year, end_year: Time.now.year - 100, prompt: { day: '日', month: '月', year: '年' }, use_month_numbers: true }, { class: "form-select" }
+            .form-group
+              = f.label :profile_image, "プロフィール背景画像", class: "user-edit-form__label"
+              = f.file_field :profile_image, class: "form-control"
+            - if @user.profile_image.attached?
+              / ▼ image_processing を入れたけどなぜか表示されない..何か忘れている可能性がある為一旦コメントアウト
+              / = image_tag(@user.profile_image.variant(resize_to_limit: [300, 400]))
+              = image_tag @user.profile_image, class: "user-edit-form__profile_img"
+            .form-group
+              = f.label :avatar_image, "アイコン画像", class: "user-edit-form__label"
+              = f.file_field :avatar_image, class: "form-control"
+            - if @user.avatar_image.attached?
+              / = image_tag(@user.avatar_image.variant(resize_to_limit: [300, 500]))
+              = image_tag @user.avatar_image, class: "user-edit-form__avatar_img"
+            .form-group
+              = f.label :password, "パスワード", class: "user-edit-form__label"
+              = f.password_field :password, autocomplete: "new-password", class: "form-control"
+            .form-group
+              = f.label :password_confirmation, "パスワード確認", class: "user-edit-form__label"
+              = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
+            .form-group.form-group__submit
+              = f.submit "編集する", class: "btn btn-info w-100 user-edit-btn"

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,8 @@ module Myapp
       g.factory_bot false
     end
     config.action_view.default_form_builder = 'ApplicationFormBuilder'
+
+    # デフォルトのロケールを日本語に設定
+    # config.i18n.default_locale = :ja
   end
 end


### PR DESCRIPTION
## 課題のリンク

* https://x-clone-web.onrender.com

## やったこと

* 自分のユーザープロフィールを編集できるようにしました
  * ユーザープロフィールページ右上のプロフィール編集ボタンよりユーザー編集画面に遷移するようにしました
  * ユーザー名・メールアドレス・電話番号・自己紹介・場所・ウェブサイト・生年月日・プロフィール画像・アイコン画像・パスワードの項目を修正できるようにしました
  * passwordを変更しない場合に、deviseの機能でバリデーションチェックされるので、パスワード・パスワード確認を変更しない (フォーム内が空のまま) なら更新対象から除外するようにしました
  * deviseの機能で、passwordを更新した場合に現在のセッションが無効になる為、password更新した場合は再ログインする処理を追加しました


## 動作確認方法

* 以下のテスト用アカウントでログイン
  * email : `test-prd01@gmail.com`
  * password : `testprd01`
* [トップページ](https://x-clone-web.onrender.com/)のサイドバー、プロフィールアイコンよりユーザープロフィールページに遷移
* プロフィールを編集ボタンよりプロフィール編集画面に遷移
* 任意のデータを更新して、更新完了後、ユーザープロフィール画面に遷移して「プロフィールを変更しました」のフラッシュメッセージが表示されることを確認
## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
  * 現状特になしです
