### PR TITLE
ツイート作成機能 追加

### DIFF
--- a/app/assets/stylesheets/tweets/form.scss
+++ b/app/assets/stylesheets/tweets/form.scss
@@ -15,18 +15,19 @@
 }
 
 .tweet-form__textarea {
-	width: 100%;
+	// width: 100%;
 	border: none;
-	height: 128px;
+	height: 110px;
 	resize: none; 
 	outline: 0;
 	background-color: black;
 	color: white;
+	width: 500px;
 }
 
 .tweet-form__textarea::placeholder {
 	padding: 40px 0 0 20px;
-  font-size: 30px;
+  font-size: 25px;
 }
 
 .tweet-form__footer  {
@@ -43,7 +44,7 @@
 	background: black;
 	color: #2B9BF0;
 	border: none;
-	font-size: 30px;
+	font-size: 25px;
 }
 
 .tweet-form__img-up-btn .form-control-file {

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -4,6 +4,20 @@ class TweetsController < ApplicationController
   def create; end
 
   def show; end
+  def create
+    # 1. ログインユーザーの投稿インスタンスをメモリ上に作成
+    # 2. 画像を@tweetインスタンスに紐づける
+    # 3. 保存(データ永続化)して、成功ならホームページにリダイレクト
+    @user = current_user
+    @tweet = current_user.tweets.build(tweet_params)
+    @tweet.image.attach(params[:tweet][:image])
+    if @tweet.save
+      redirect_to root_path, notice: 'ツイートしました'
+    else
+      set_top_page_tweets # トップページ描画に必要なデータを準備
+      render template: 'home/index', status: :unprocessable_entity
+    end
+  end
 
   def edit; end
 

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -23,6 +23,16 @@ class TweetsController < ApplicationController
   def update; end
 
   def destroy; end
+
+  private
+
+  # ▼ コメント作成失敗時にも呼び出すので共通化
+  # def set_tweet
+  #   # @tweet = Tweet.find_by(id: params[:id])
+  #   @tweet = Tweet.includes(:comments).find_by(id: params[:id])
+  #   logger.debug "投稿したユーザー: #{@tweet.comments.inspect}"
+  # end
+
   def tweet_params
     params.require(:tweet).permit(:content, :image)
   end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,7 +2,6 @@
 
 class TweetsController < ApplicationController
 
-  def show; end
   def create
     # 1. ログインユーザーの投稿インスタンスをメモリ上に作成
     # 2. 画像を@tweetインスタンスに紐づける

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -24,4 +24,7 @@ class TweetsController < ApplicationController
   def update; end
 
   def destroy; end
+  def tweet_params
+    params.require(:tweet).permit(:content, :image)
+  end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TweetsController < ApplicationController
-  def create; end
 
   def show; end
   def create

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -10,8 +10,6 @@ class Tweet < ApplicationRecord
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 140 }
   validates :image, content_type: { in: ['image/jpeg', 'image/gif', 'image/png'], message: '適切な画像フォーマットを使用してください' }
-  # validates :image, content_type: { in: ['image/jpeg', 'image/gif', 'image/png'],
-  #   message: '適切な画像フォーマットを使用してください' }
 
   # ツイート一覧取得
   scope :recommended_tweets, lambda { |page|

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,7 +2,16 @@
 
 class Tweet < ApplicationRecord
   belongs_to :user
-  has_one_attached :images
+  has_one_attached :image
+  # has_many :comments, dependent: :destroy
+  # has_many :likes, dependent: :destroy
+  # has_many :liked_users, through: :likes, source: :user
+
+  validates :user_id, presence: true
+  validates :content, presence: true, length: { maximum: 140 }
+  validates :image, content_type: { in: ['image/jpeg', 'image/gif', 'image/png'], message: '適切な画像フォーマットを使用してください' }
+  # validates :image, content_type: { in: ['image/jpeg', 'image/gif', 'image/png'],
+  #   message: '適切な画像フォーマットを使用してください' }
 
   # ツイート一覧取得
   scope :recommended_tweets, lambda { |page|

--- a/app/views/tweets/_form.html.slim
+++ b/app/views/tweets/_form.html.slim
@@ -1,4 +1,9 @@
-= form_with(model: @tweet, class: "tweet-form__container", local: true) do |f|
+= form_with(model: @tweet, url: tweets_path, class: "tweet-form__container", local: true) do |f|
+  - if @tweet.errors.any?
+    .alert.alert-danger
+      ul
+        - @tweet.errors.full_messages.each do |msg|
+          li = msg
   .tweet-form__main
     = link_to user_path(current_user), class: "nav-link nav-link__icon" do 
       - if current_user.avatar_image.attached?
@@ -7,10 +12,9 @@
         = image_tag 'tweet-icon.png', class: 'tweet-form__icon-img'
     = f.text_area :content, class: "tweet-form__textarea", placeholder: "今どうしてる？"
   .tweet-form__footer 
-    .tweet-form_img-up-area data-controller="image-upload"
-      label.tweet-form__img-up-btn data-action="click->image-upload#openFileField"
+    .tweet-form_img-up-area
+      label.tweet-form__img-up-btn
         i.bi.bi-image
-        = f.file_field :image, { accept: "image/jpeg,image/gif,image/png", class: "form-control-file d-none", direct_upload: true, "data-image-upload-target": "fileField" }
-      img#image-preview.image-preview[data-image-upload-target="imagePreview" style="display: none;"]
+        = f.file_field :image, class: "form-control-file"
     .tweet-form__post-btn-area 
       = f.submit "ポストする", class: "tweet-form__post_btn btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,7 @@ Rails.application.routes.draw do
   # resources :users, only: [:show, :edit]
   resources :users
 
-  post '/tweets', to: 'tweets#create'
+  # post '/tweets/create', to: 'tweets#create'
+  # get '/tweets/:id', to: 'tweets#show'
+  resources :tweets
 end

--- a/render-build.sh
+++ b/render-build.sh
@@ -11,7 +11,9 @@ rails db:migrate
 # rails db:seed
 
 # Renderコンソールに設定用のコマンド▼
-
+# デフォルト▼
 # bundle install && rails assets:precompile && rails assets:clean && rails db:migrate
 
-# bundle install && rails assets:precompile && rails assets:clean && rails db:create && rails db:migrate && rails db:seed
+# bundle install && rails assets:precompile && rails assets:clean && rails db:migrate && rails db:seed && rails user:attach_images
+
+# bundle install && rails assets:precompile && rails assets:clean && rails db:create && rails db:migrate


### PR DESCRIPTION
## 課題のリンク

* https://x-clone-web.onrender.com

## やったこと

* トップページ (ルートパス) のツイート投稿用のフォームから、ツイートと画像1つを投稿出来るようにしました
* 以下を行った場合にエラーメッセージが出るようにしました
  * 空の投稿
  * 140文字以上の投稿
  * `jpeg, gif, png`以外の形式の画像投稿
* 投稿が完了するとトップページの一覧画面の投稿一覧最上部に投稿が反映されるようにしました
* 投稿フォームの画像アイコンやプレースホルダーを小さくしました (レイアウト修正)


## 動作確認方法

* 以下のテスト用アカウントでログイン
  * email : `test-prd01@gmail.com`
  * password : `testprd01`
* トップページ (ルートパス) のツイート投稿用のフォームから、ツイートと画像1つを投稿出来る事を確認
* 以下を行った場合にエラーメッセージが出る事を確認
  * 空の投稿
  * 140文字以上の投稿
  * `jpeg, gif, png`以外の形式の画像投稿
* 投稿が成功したらトップページに遷移して投稿一覧に自身が投稿したツイートが反映されている事を確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
  * 前回の[トップページのPR- その他の2つ目に記載](https://github.com/yuuu1654/twitter_clone/pull/4)の際に、JavaScriptライブラリのStimulusを使って投稿時の画像表示を実装して不具合が出ていましたが、仕様より画像プレビューが不要ということもあり、今回はform_withを使ったシンプルな画像投稿を実装しています