### PR TITLE
リツイート機能 作成

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.16.0-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -412,6 +414,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -34,3 +34,25 @@ body {
     color: #ff2581;
   }
 }
+// リツイート
+.retweet-btn {
+  color: #8899a6;
+}
+.retweet-btn__link {
+  color: #8899a6;
+	text-decoration: none;
+  &:hover {
+    color: #8899a6;
+  }
+}
+
+.retweet-btn-unretweet {
+  color: #06BA7C;
+}
+.retweet-btn-unretweet__link {
+	text-decoration: none;
+  color: #06BA7C;
+  &:hover {
+    color: #06BA7C;
+  }
+}

--- a/app/controllers/retweets_controller.rb
+++ b/app/controllers/retweets_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class RetweetsController < ApplicationController
+  before_action :set_retweet, only: [:destroy]
+
+  def create
+    @tweet = Tweet.find_by(id: params[:tweet_id])
+    current_user.retweet_tweet(@tweet)
+    # @tweet.touch ← モデルのバリデーションをスキップするので好ましくない..
+    @tweet.update(updated_at: Time.current)
+    redirect_to request.referer
+  end
+
+  def destroy
+    @tweet = Tweet.find_by(id: @retweet.tweet_id)
+    @retweet.destroy
+    @tweet.update(updated_at: @tweet.created_at)
+    redirect_to request.referer
+  end
+
+  private
+
+  def set_retweet
+    @retweet = current_user.retweets.find_by(id: params[:id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
   end
 
   def fetch_retweeted_tweets
-    @retweeted_tweets = Tweet.where(content: 'リツイートした投稿です').page(params[:page]).per(10)
+    @retweeted_tweets = @user.retweeted_tweets.page(params[:page]).per(10)
   end
 
   def fetch_commented_tweets

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,4 +15,20 @@ module UsersHelper
       end
     end
   end
+
+  def retweet_or_unretweet_button(user, tweet)
+    retweet = Retweet.find_by(user_id: user.id, tweet_id: tweet.id)
+    retweets_count = tweet.retweets.count
+    if user.retweeted?(tweet)
+      link_to retweet_path(retweet), method: :delete, data: { turbo_method: :delete },
+                                     class: 'retweet-btn-unretweet__link' do
+        tag.i('', class: 'bi bi-repeat retweet-btn-unretweet') + " #{retweets_count}"
+      end
+    else
+      link_to retweets_path(tweet_id: tweet.id), method: :post, data: { turbo_method: :post },
+                                                 class: 'retweet-btn__link' do
+        tag.i('', class: 'bi bi-repeat retweet-btn') + " #{retweets_count}"
+      end
+    end
+  end
 end

--- a/app/models/retweet.rb
+++ b/app/models/retweet.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Retweet < ApplicationRecord
+  belongs_to :user
+  belongs_to :tweet
+
+  validates :user_id, presence: true
+  validates :tweet_id, presence: true
+  validates :user_id, uniqueness: { scope: :tweet_id }
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -6,6 +6,8 @@ class Tweet < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
+  has_many :retweets, dependent: :destroy
+  has_many :retweeted_users, through: :retweets, source: :user
 
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 140 }

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -16,7 +16,7 @@ class Tweet < ApplicationRecord
   # ツイート一覧取得
   scope :recommended_tweets, lambda { |page|
     includes(:user)
-      .order(created_at: :desc)
+      .order(updated_at: :desc)
       .page(page)
       .per(10)
   }
@@ -34,7 +34,7 @@ class Tweet < ApplicationRecord
   scope :my_tweets, lambda { |user_id, page|
     where(user_id:)
       .includes(:user)
-      .order(created_at: :desc)
+      .order(updated_at: :desc)
       .page(page)
       .per(10)
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_tweets, -> { order('likes.created_at desc') }, through: :likes, source: :tweet # いいねしたツイートの集合
+  has_many :retweets, dependent: :destroy
+  has_many :retweeted_tweets, through: :retweets, source: :tweet # リツイートしたツイートの集合
   has_one_attached :avatar_image
   has_one_attached :profile_image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,4 +51,18 @@ class User < ApplicationRecord
     like = Like.find_by(user_id: user.id, tweet_id: tweet.id)
     like&.destroy
   end
+
+  # リツイート関連
+  def retweeted?(tweet)
+    retweeted_tweets.include?(tweet)
+  end
+
+  def retweet_tweet(tweet)
+    retweets.create(tweet_id: tweet.id)
+  end
+
+  def unretweet_tweet(user, tweet)
+    retweet = Retweet.find_by(user_id: user.id, tweet_id: tweet.id)
+    retweet&.destroy
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,9 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_tweets, -> { order('likes.created_at desc') }, through: :likes, source: :tweet # いいねしたツイートの集合
   has_many :retweets, dependent: :destroy
-  has_many :retweeted_tweets, -> { order('retweets.created_at desc') }, through: :retweets, source: :tweet # リツイートしたツイートの集合
+  has_many :retweeted_tweets, lambda {
+                                order('retweets.created_at desc')
+                              }, through: :retweets, source: :tweet # リツイートしたツイートの集合
   has_one_attached :avatar_image
   has_one_attached :profile_image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,5 +68,4 @@ class User < ApplicationRecord
   #   retweet = Retweet.find_by(user_id: user.id, tweet_id: tweet.id)
   #   retweet&.destroy
   # end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,8 +61,10 @@ class User < ApplicationRecord
     retweets.create(tweet_id: tweet.id)
   end
 
-  def unretweet_tweet(user, tweet)
-    retweet = Retweet.find_by(user_id: user.id, tweet_id: tweet.id)
-    retweet&.destroy
+  # ▼使わなかったので、一旦コメントアウト
+  # def unretweet_tweet(user, tweet)
+  #   retweet = Retweet.find_by(user_id: user.id, tweet_id: tweet.id)
+  #   retweet&.destroy
+  # end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_tweets, -> { order('likes.created_at desc') }, through: :likes, source: :tweet # いいねしたツイートの集合
   has_many :retweets, dependent: :destroy
-  has_many :retweeted_tweets, through: :retweets, source: :tweet # リツイートしたツイートの集合
+  has_many :retweeted_tweets, -> { order('retweets.created_at desc') }, through: :retweets, source: :tweet # リツイートしたツイートの集合
   has_one_attached :avatar_image
   has_one_attached :profile_image
 

--- a/app/views/tweets/_tweet.html.slim
+++ b/app/views/tweets/_tweet.html.slim
@@ -18,8 +18,7 @@
       .action-icon__area
         i.bi.bi-chat
       .action-icon__area
-        i.bi.bi-repeat
-        / = retweet_or_unretweet_button(current_user, tweet)
+        = retweet_or_unretweet_button(current_user, tweet)
       .action-icon__area
         = like_or_unlike_button(current_user, tweet)
       .action-icon__area

--- a/app/views/tweets/show.html.slim
+++ b/app/views/tweets/show.html.slim
@@ -35,7 +35,7 @@
             .detail-action-icon__area
               i.bi.bi-chat.tweet-detail__action-icon
             .detail-action-icon__area
-              i.bi.bi-repeat.tweet-detail__action-icon
+              = retweet_or_unretweet_button(current_user, @tweet)
             .detail-action-icon__area
               = like_or_unlike_button(current_user, @tweet)
             .detail-action-icon__area

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,5 @@ Rails.application.routes.draw do
   # post "/likes/:tweet_id/create", to: "likes#create"
   # delete "/likes/:tweet_id/destroy", to: "likes#destroy"
   resources :likes, only: %i[create destroy]
+  resources :retweets, only: %i[create destroy]
 end

--- a/db/migrate/20240220105717_create_retweets.rb
+++ b/db/migrate/20240220105717_create_retweets.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateRetweets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :retweets do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :tweet, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240221035216_add_unique_constraint_to_retweets.rb
+++ b/db/migrate/20240221035216_add_unique_constraint_to_retweets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToRetweets < ActiveRecord::Migration[7.0]
+  def change
+    add_index :retweets, %i[user_id tweet_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_045057) do
     t.index ["user_id", "tweet_id"], name: "index_likes_on_user_id_and_tweet_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
+  create_table "retweets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "tweet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tweet_id"], name: "index_retweets_on_tweet_id"
+    t.index ["user_id", "tweet_id"], name: "index_retweets_on_user_id_and_tweet_id", unique: true
+    t.index ["user_id"], name: "index_retweets_on_user_id"
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -133,5 +143,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_045057) do
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "likes", "tweets"
   add_foreign_key "likes", "users"
+  add_foreign_key "retweets", "tweets"
+  add_foreign_key "retweets", "users"
   add_foreign_key "tweets", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -102,6 +102,12 @@
 # liked_tweets = tweets[15..20]
 # liked_tweets.each { |tweet| test_user.like_tweet(tweet) }
 
+# リツイートデータ作成
+tweets = Tweet.all
+test_user = User.find_by(email: 'test-prd01@gmail.com')
+retweeted_tweets = tweets[15..20]
+retweeted_tweets.each { |tweet| test_user.retweet_tweet(tweet) }
+
 # # フォロー関係作成
 # Follow.find_or_create_by(follower_id: test_user.id, followed_id: followed_user.id)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -103,10 +103,10 @@
 # liked_tweets.each { |tweet| test_user.like_tweet(tweet) }
 
 # リツイートデータ作成
-tweets = Tweet.all
-test_user = User.find_by(email: 'test-prd01@gmail.com')
-retweeted_tweets = tweets[15..20]
-retweeted_tweets.each { |tweet| test_user.retweet_tweet(tweet) }
+# tweets = Tweet.all
+# test_user = User.find_by(email: 'test-prd01@gmail.com')
+# retweeted_tweets = tweets[15..20]
+# retweeted_tweets.each { |tweet| test_user.retweet_tweet(tweet) }
 
 # # フォロー関係作成
 # Follow.find_or_create_by(follower_id: test_user.id, followed_id: followed_user.id)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/retweet_spec.rb
+++ b/spec/models/retweet_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Retweet, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Comments', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/retweets_spec.rb
+++ b/spec/requests/retweets_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Retweets', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 課題のリンク

* https://x-clone-web.onrender.com

## やったこと

* ツイート一覧の各ツイート・ツイート詳細画面上で、ツイートに対して「リツイート」出来るようにしました
  * リピートアイコンをクリックすると「リツイート」ができて、アイコンがグリーンに変わる
  * もう一度クリックするとリツイートが解除できて、リツイート前のアイコン色に戻る
  * リピートアイコンの横に「リツイート」の総数を表示
  * リツイートしたツイートをユーザープロフィールのリツイート一覧から見れるようにしました
  * リツイートしたツイートはツイート一覧の最上部に表示され、リツイートを取り消すと元の位置に戻る
* 実装面
  * リツイートを考慮したツイート一覧にするべく、ツイートを`updated_at`の降順で一覧取得&表示して、以下のように表示位置を切り替えました
    * リツイートすると、ツイートの`updated_at`を現在日時に更新
    * リツイートを取り消すと、ツイートの`updated_at`をツイート作成時に更新
  * リツイート表示切り替え処理をヘルパーメソッドに切り出しました
  * `has_many, has_many :through関連付け`を使用して、Userモデルに以下の便利メソッドを実装
    * ユーザーが「リツイート」したツイートをリツイート日時の降順で取得
    * リツイート登録処理・削除処理
    * ユーザーがリツイートしたかどうかを判定する処理
  * リツイート表示切り替えをしたページに遷移するようにしました
  * リツイートデータ作成用のseed作成 
* 修正
  * 


## 動作確認方法

* 以下のテスト用アカウントでログイン
  * email : `test-prd01@gmail.com`
  * password : `testprd01`
* ログイン完了後、ホーム画面のツイート一覧より任意のツイートに対して「リツイート」する
* リピートアイコンがグリーン色に変わり、カウントが+1される事を確認
* もう一度クリックすると、リピートアイコンが「リツイート」する前の状態に戻り、カウントも-1される事を確認
* 同様に、任意のツイートの詳細ページからも上記の手順で「リツイート」の表示切り替えができる事を確認
* 左側サイドバーのプロフィールアイコンより、ユーザープロフィール画面に遷移し、リツイート一覧タブにて、上記で「リツイート」したツイートが、「リツイート」した日時の降順で表示される事を確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
  * いいね機能とほとんど同じ流れで実装いたしました