### PR TITLE
メッセージ機能 作成

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -19,4 +19,7 @@
 @import "tweets/action-modal";
 @import "bookmarks/index";
 @import "rooms/index";
+@import "rooms/show";
 @import "rooms/room";
+@import "messages/form";
+@import "messages/feed";

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -19,3 +19,4 @@
 @import "tweets/action-modal";
 @import "bookmarks/index";
 @import "rooms/index";
+@import "rooms/room";

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -18,3 +18,4 @@
 @import "./common";
 @import "tweets/action-modal";
 @import "bookmarks/index";
+@import "rooms/index";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -7,6 +7,9 @@ body {
   border-top: 0;
   border-bottom: 0;
   padding: 0;
+  overflow-y: auto;
+  min-height: 900px;
+  max-height: calc(100vh - 130px);
 }
 .col-md-5 {
   border: 0.9px solid rgba(186, 212, 230, 0.469);

--- a/app/assets/stylesheets/messages/feed.scss
+++ b/app/assets/stylesheets/messages/feed.scss
@@ -1,0 +1,39 @@
+.message-list {
+  .message {
+    margin-bottom: 10px;
+
+    &.my-message {
+      .message-content {
+        background-color: #188CD8;
+        color: white;
+        padding: 1px 10px;
+        border-radius: 20px 20px 3px 20px;
+        margin: 0 10px 0 150px;
+      }
+
+      .message-timestamp {
+        margin-right: 10px;
+        color: #8899a6;
+        text-align: right;
+      }
+    }
+
+    &.partner-message {
+      .message-content {
+        background-color: #2F3336;
+        color: white;
+        padding: 10px;
+        border-radius: 20px 20px 20px 3px;
+
+        padding: 1px 10px;
+        border-radius: 20px 20px 20px 3px;
+        margin: 0 150px 0 10px;
+      }
+
+      .message-timestamp {
+        margin-left: 10px;
+        color: #8899a6;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/messages/form.scss
+++ b/app/assets/stylesheets/messages/form.scss
@@ -1,0 +1,75 @@
+.message-form__container {
+	border: 0.5px solid #5c93bb2b;
+
+  .message-action__container  {
+    display: flex;
+    align-items: center;
+    background-color: black;
+  }
+
+  .message-textarea__area {
+    display: flex; // flexboxコンテナ
+    justify-content: center; // 水平方向の中心
+    align-items: center; // 垂直方向の中心
+    text-align: center; // 子要素のテキストを中心に配置
+    
+    .message-form__textarea {
+      border: none;
+      height: 60px;
+      background-color: #2F3336;
+      border-radius: 21px;
+      color: white;
+      width: 470px;
+      padding: 13px 0 0 10px;
+      margin: 7px;
+    }
+    
+    .message-form__textarea::placeholder {
+      font-size: 20px;
+    }
+  }
+
+  .message-post-btn__area {
+    position: relative; 
+
+    .message-submit__btn {
+      height: 45px;
+      width: 40px;
+      // margin-right: 10px;
+    }
+
+    .message-post-icon {
+      margin-right: 15px;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      font-size: 23px;
+      transform: rotate(45deg);
+      color: #2B9BF0;
+    }
+  }
+}
+
+.message-form__img-up-btn  {
+	background: black;
+	color: #2B9BF0;
+	border: none;
+	font-size: 25px;
+}
+
+.message-form__img-up-btn .form-control-file {
+  display: none;
+}
+
+.image-preview {
+  width: 300px; 
+  height: auto; 
+  max-height: 500px; 
+}
+
+.message-form__post_btn {
+	color: white;
+	font-weight: bold;
+	background-color: #2B9BF0;
+	border-radius: 20px;
+}

--- a/app/assets/stylesheets/rooms/index.scss
+++ b/app/assets/stylesheets/rooms/index.scss
@@ -1,0 +1,23 @@
+.message-list__title-area {
+  // height: 40px;
+  border: 0.9px solid rgba(92, 147, 187, 0.168627451);
+}
+
+.message-list__title {
+  font-weight: bold;
+  color: white;
+  padding: 15px 0 10px 15px;
+}
+
+.message-detail__area {
+  display: flex; // flexboxコンテナ
+  justify-content: center; // 水平方向の中心
+  align-items: center; // 垂直方向の中心
+  text-align: center; // 子要素のテキストを中心に配置
+  height: 100%; // 親要素の高さが指定されている必要がある
+  // 以下のプロパティは`.message-detail__area`の高さが設定されていない場合に役立つ
+  
+  .message-detail-announce {
+    
+  }
+}

--- a/app/assets/stylesheets/rooms/room.scss
+++ b/app/assets/stylesheets/rooms/room.scss
@@ -1,0 +1,50 @@
+.room__container {
+	display: flex;
+	align-items: center;
+	border: 0.9px solid rgba(92, 147, 187, 0.168627451);
+	position: relative;
+}
+
+.room-icon__container {
+	// 画像の位置を修正
+	position: absolute;
+	top: 20px;
+	left: 20px;
+}
+
+.room-icon__img {
+	height: 40px;
+	width: 40px;
+	border-radius: 30px;
+}
+
+.room-info__container {
+	color: white;
+	padding: 20px 0 10px 80px;
+	width: 100%;
+	min-height: 78px;
+}
+
+.room-content__link {
+	color: white;
+	text-decoration: none;
+	&:hover {
+		color: white;
+	}
+}
+
+.room-image {
+	width: 500px;
+	height: 280px;
+	margin-bottom: 20px;
+	border-radius: 10px;
+}
+
+.room__action-area {
+	display: flex;
+	align-items: center;
+}
+
+.action-icon__area {
+	margin-right: 100px;
+}

--- a/app/assets/stylesheets/rooms/show.scss
+++ b/app/assets/stylesheets/rooms/show.scss
@@ -1,0 +1,35 @@
+.message-detail__header  {
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    padding: 15px 10px;
+    position: sticky; // fixだとレイアウト崩れた
+    top: 0;
+}
+
+.message-detail__recipient-user-name {
+    padding-left: 10px;
+    font-weight: bold;
+    color: white;
+}
+
+.message-detail__title {
+    font-weight: bold;
+    color: white;
+}
+
+.message-detail__text {
+
+}
+
+.message-detail__main {
+    overflow-y: auto; // 独立してスクロールできるようにする
+    min-height: 900px;
+    max-height: calc(100vh - 130px);  // ビューポートの高さ - (header&formの高さの合計)
+}
+
+.message-detail__form_area {
+    position: sticky;
+    bottom: 0;
+    
+}

--- a/app/assets/stylesheets/tweets/action-modal.scss
+++ b/app/assets/stylesheets/tweets/action-modal.scss
@@ -1,7 +1,7 @@
 .user-action-btn {
 	background-color: black;
 	color: white;
-	margin-left: 60px;
+	margin-left: 20px;
 }
 
 // ▼背景黒にしたけど見にくいから一旦コメントアウト
@@ -14,3 +14,8 @@
 // 	color: white;
 // 	background-color: black;
 // }
+
+.action-modal__container {
+	display: flex;
+	align-items: center;
+}

--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -38,7 +38,18 @@
 	align-items: center;
 	justify-content: space-between;
 	margin-top: 10px;
+
+	.right-area {
+		display: flex;
+    align-items: center;
+
+		.user-profile__msg-btn {
+			margin-right: 20px;
+		}
+	}
 }
+
+
 
 .user-profile__icon-img {
 

--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -1,6 +1,7 @@
-// .col-md-6 {
-// 	border: 0.5px solid #9b9a9a;
-// }
+.home-link {
+	color: white;
+	margin: 5px 10px;
+}
 
 .user-profile__container {
 
@@ -63,11 +64,6 @@
 
 .user-profile__name {
 	color: white;
-}
-
-.home-link {
-	color: white;
-	margin: 5px 10px;
 }
 
 .user-profile__user-name {

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BookmarksController < ApplicationController
+  before_action :logged_in_user?, only: [:index]
   before_action :set_bookmark, only: [:destroy]
 
   def index

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MessagesController < ApplicationController
+  def create
+    @room = Room.find(params[:room_id])
+    @message = @room.messages.build(message_params)
+    @message.sender = current_user
+    @message.recipient = User.find(params[:other_user_id])
+    if @message.save
+      redirect_to room_show_path(params[:room_id])
+    else
+      render template: 'rooms/show', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:body)
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -8,9 +8,11 @@ class RoomsController < ApplicationController
 
   def create
     other_user = User.find(params[:user_id])
-    other_user_entry = Entry.find_by(user_id: other_user.id)
-    if other_user_entry
-      redirect_to room_show_path(other_user_entry.room_id)
+    # 自分と相手がすでに参加しているルームを探す
+    shared_room = Room.shared_room(current_user.id, other_user.id)
+
+    if shared_room
+      redirect_to room_show_path(shared_room.id)
     else
       @room = Room.create do |room|
         room.entries.build(user: current_user)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -10,7 +10,7 @@ class RoomsController < ApplicationController
     other_user = User.find(params[:user_id])
     other_user_entry = Entry.find_by(user_id: other_user.id)
     if other_user_entry
-      redirect_to messages_path
+      redirect_to room_show_path(other_user_entry.room_id)
     else
       @room = Room.create do |room|
         room.entries.build(user: current_user)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class RoomsController < ApplicationController
+  before_action :logged_in_user?, only: %i[index show]
+  before_action :set_rooms, only: %i[index show]
+  before_action :set_room, only: [:show]
+  before_action :set_other_user, only: [:show]
+
+  def create
+    other_user = User.find(params[:user_id])
+    other_user_entry = Entry.find_by(user_id: other_user.id)
+    unless other_user_entry
+      @room = Room.create do |room|
+        room.entries.build(user: current_user)
+        room.entries.build(user: other_user)
+      end
+      redirect_to room_show_path(@room)
+    else
+      redirect_to messages_path
+    end
+  end
+
+  def index; end
+
+  def show
+    @message = Message.new
+    @messages = @room.messages.order(created_at: :asc)
+  end
+
+  private
+
+  def set_rooms
+    @rooms = current_user.rooms.includes(:messages)
+  end
+
+  def set_room
+    @room = Room.includes(:messages).find_by(id: params[:room_id])
+  end
+
+  def set_other_user
+    @other_user = @room.users.where.not(id: current_user.id).first
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -9,14 +9,14 @@ class RoomsController < ApplicationController
   def create
     other_user = User.find(params[:user_id])
     other_user_entry = Entry.find_by(user_id: other_user.id)
-    unless other_user_entry
+    if other_user_entry
+      redirect_to messages_path
+    else
       @room = Room.create do |room|
         room.entries.build(user: current_user)
         room.entries.build(user: other_user)
       end
       redirect_to room_show_path(@room)
-    else
-      redirect_to messages_path
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -57,8 +57,15 @@ module UsersHelper
     else
       link_to relationships_path(followed_id: other_user.id), method: :post, data: { turbo_method: :post },
                                                               class: 'user-action-link dropdown-item' do
-        content_tag(:i, '', class: 'bi bi-person-plus') + " #{other_user.name}さんをフォローする"
+        content_tag(:i, '', class: 'bi bi-person-plus') + " #{other_user.username}さんをフォローする"
       end
+    end
+  end
+
+  def message_button(tweet)
+    link_to rooms_path(user_id: tweet.user.id), method: :post, data: { turbo_method: :post },
+                                                class: 'user-action-link dropdown-item' do
+      content_tag(:i, '', class: 'bi bi-envelope') + " #{tweet.user.username}さんにメッセージを送信する"
     end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./packs/message-feed"
 import * as bootstrap from "bootstrap"
 import "@fortawesome/fontawesome-free/js/all"

--- a/app/javascript/packs/message-feed.js
+++ b/app/javascript/packs/message-feed.js
@@ -1,0 +1,6 @@
+document.addEventListener('turbo:load', () => {
+  const messagesMainArea = document.querySelector('.message-detail__main');
+  if (messagesMainArea) {
+    messagesMainArea.scrollTop = messagesMainArea.scrollHeight;
+  }
+});

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Entry < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Message < ApplicationRecord
+  belongs_to :room
+  belongs_to :sender, class_name: 'User'
+  belongs_to :recipient, class_name: 'User'
+  validates :sender_id, presence: true
+  validates :recipient_id, presence: true
+  validates :room_id, presence: true
+  validates :body, presence: true
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Room < ApplicationRecord
+  has_many :entries, dependent: :destroy
+  has_many :users, through: :entries, dependent: :destroy
+  has_many :messages, dependent: :destroy
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -4,4 +4,13 @@ class Room < ApplicationRecord
   has_many :entries, dependent: :destroy
   has_many :users, through: :entries, dependent: :destroy
   has_many :messages, dependent: :destroy
+
+  # 自分と相手のエントリーに紐づいているルームを取得
+  def self.shared_room(current_user_id, other_user_id)
+    joins('inner join entries as e1 on e1.room_id = rooms.id')
+      .joins('inner join entries as e2 on e2.room_id = rooms.id')
+      .where('e1.user_id = ? and e2.user_id = ?', current_user_id, other_user_id)
+      .distinct
+      .first
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,10 @@ class User < ApplicationRecord
                                    dependent: :destroy,
                                    inverse_of: :followed
   has_many :followers, through: :passive_relationships, source: :follower # フォロワーの集合
-
+  # メッセージ関連
+  has_many :entries, dependent: :destroy
+  has_many :rooms, through: :entries, dependent: :destroy
+  has_many :messages, dependent: :destroy
   has_one_attached :avatar_image
   has_one_attached :profile_image
 

--- a/app/views/messages/_feed.html.slim
+++ b/app/views/messages/_feed.html.slim
@@ -1,0 +1,15 @@
+.message-list 
+  - if message.sender_id == current_user.id 
+    / 自分のメッセージ
+    .message.my-message 
+      .message-content 
+        p = simple_format message.body
+      .message-timestamp
+        span = message.created_at.strftime('%Y年%m月%d日 %H:%M')
+  - else 
+    / 相手のメッセージ
+    .message.partner-message 
+      .message-content 
+        p = simple_format message.body
+      .message-timestamp
+        span = message.created_at.strftime('%Y年%m月%d日 %H:%M')

--- a/app/views/messages/_form.html.slim
+++ b/app/views/messages/_form.html.slim
@@ -1,0 +1,12 @@
+= form_with(model: @message, url: messages_path(room_id: @room.id, other_user_id: other_user.id), class: "message-form__container", local: true) do |f|
+  - if @message.errors.any?
+    .alert.alert-danger
+      ul
+        - @message.errors.full_messages.each do |msg|
+          li = msg
+  .message-action__container 
+    .message-textarea__area 
+      = f.text_area :body, class: "message-form__textarea", placeholder: "新しいメッセージを作成"
+    .message-post-btn__area
+      button type="submit" class="btn btn-default message-submit__btn"
+        i.bi.bi-send.message-post-icon

--- a/app/views/rooms/_room.html.slim
+++ b/app/views/rooms/_room.html.slim
@@ -1,0 +1,15 @@
+.room__container 
+  .room-icon__container
+    - other_user = room.users.where.not(id: current_user.id).first
+    - if other_user.avatar_image.attached?
+      = link_to user_path(other_user), class: "" do 
+        = image_tag(other_user.avatar_image, class: "room-icon__img")
+    - else
+      = link_to user_path(other_user), class: "" do 
+        = image_tag('user-icon.png', class: 'room-icon__img')
+  .room-info__container 
+    = link_to room_show_path(room), class: "room-content__link" do
+      .room-name__area
+        span = other_user.name 
+      .room-content__area
+        span = room.messages.last.body.truncate(15) if room.messages.last.present?

--- a/app/views/rooms/index.html.slim
+++ b/app/views/rooms/index.html.slim
@@ -1,0 +1,19 @@
+
+/ = render "layouts/navigation"
+
+= render "/users/shared/notice"
+.container.px-4.px-lg-5
+  .row
+    .col-md-3
+      = render "tweets/sidebar", user: current_user
+    .col-md-4
+      / メッセージ相手の一覧 (クリックすると対象のユーザーとのメッセージ詳細画面が表示)
+      .message-list__title-area
+        h4.message-list__title メッセージ
+      = render partial: "rooms/room", collection: @rooms, as: :room
+    .col-md-5
+      .message-detail__area 
+        .message-detail-announce
+          h3.message-detail__title メッセージを選択
+          br
+          p.message-detail__text  既存の会話から選択したり、新しい会話を開始できたりします

--- a/app/views/rooms/show.html.slim
+++ b/app/views/rooms/show.html.slim
@@ -1,0 +1,26 @@
+
+/ = render "layouts/navigation"
+
+= render "/users/shared/notice"
+.container.px-4.px-lg-5
+  .row
+    .col-md-3
+      = render "tweets/sidebar", user: current_user
+    .col-md-4
+      / メッセージ相手の一覧 (クリックすると対象のユーザーとのメッセージ詳細画面が表示)
+      .message-list__title-area
+        h4.message-list__title メッセージ
+      = render partial: "rooms/room", collection: @rooms, as: :room
+    .col-md-5
+      .message-detail__header 
+        .message-detail__user-icon 
+          - if @other_user.avatar_image.attached?
+            = image_tag(@other_user.avatar_image, class: "tweet-icon__img")
+          - else
+            = image_tag('user-icon.png', class: 'tweet-icon__img')
+        .message-detail__recipient-user-name
+          span.recipient-user-name = @other_user.name
+      .message-detail__main
+        = render partial: 'messages/feed', collection: @messages, as: :message
+      .message-detail__form_area
+        = render 'messages/form', other_user: @other_user

--- a/app/views/tweets/_action_modal.html.slim
+++ b/app/views/tweets/_action_modal.html.slim
@@ -1,8 +1,12 @@
 / 3点ボタンのドロップダウンメニュー
 - if current_user != other_user
-  .dropdown
-    button.user-action-btn.btn type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" 
-      | •••
-    ul.user-action-items.dropdown-menu aria-labelledby="dropdownMenuButton"
-      li
-        = follow_or_unfollow_button(current_user, other_user)
+  .action-modal__container
+    .room-content__area
+      = link_to rooms_path(user_id: @tweet.user.id),method: :post, data: { turbo_method: :post }, class: "room-content__link" do
+        i.bi.bi-envelope
+    .dropdown
+      button.user-action-btn.btn type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" 
+        | •••
+      ul.user-action-items.dropdown-menu aria-labelledby="dropdownMenuButton"
+        li
+          = follow_or_unfollow_button(current_user, other_user)

--- a/app/views/tweets/_action_modal.html.slim
+++ b/app/views/tweets/_action_modal.html.slim
@@ -2,7 +2,7 @@
 - if current_user != other_user
   .action-modal__container
     .room-content__area
-      = link_to rooms_path(user_id: @tweet.user.id),method: :post, data: { turbo_method: :post }, class: "room-content__link" do
+      / = link_to rooms_path(user_id: @tweet.user.id),method: :post, data: { turbo_method: :post }, class: "room-content__link" do
         i.bi.bi-envelope
     .dropdown
       button.user-action-btn.btn type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" 
@@ -10,3 +10,4 @@
       ul.user-action-items.dropdown-menu aria-labelledby="dropdownMenuButton"
         li
           = follow_or_unfollow_button(current_user, other_user)
+          = message_button(@tweet)

--- a/app/views/tweets/_sidebar.html.slim
+++ b/app/views/tweets/_sidebar.html.slim
@@ -21,7 +21,7 @@ nav
 				| 通知
 	ul.nav.flex-column
 		li.nav-item
-			a.nav-link.nav-link__icon href="#"
+			= link_to messages_path, class: "nav-link nav-link__icon" do 
 				i.bi.bi-envelope
 				| メッセージ
 	ul.nav.flex-column

--- a/app/views/tweets/show.html.slim
+++ b/app/views/tweets/show.html.slim
@@ -14,10 +14,11 @@
             h4 ← ポストする
         .user-info__container 
           .user-icon__area 
-            - if @tweet.user.avatar_image.attached?
-              = image_tag(@tweet.user.avatar_image, class: "tweet-icon__img")
-            - else
-              = image_tag('user-icon.png', class: 'tweet-icon__img')
+            = link_to user_path(@tweet.user), class: "" do 
+              - if @tweet.user.avatar_image.attached?
+                = image_tag(@tweet.user.avatar_image, class: "tweet-icon__img")
+              - else
+                = image_tag('user-icon.png', class: 'tweet-icon__img')
           .user-info__area 
             p.posted-user__name = @tweet.user.name
             p.posted-user__user-name = @tweet.user.username ||= "@yuuu1654"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -20,8 +20,12 @@
 							.user-profile__icon-area 
 								.user-profile__icon-img
 									= @user.avatar_image.attached? ? image_tag(@user.avatar_image, class: "foreground-img") : image_tag('user-icon.png', class: "foreground-img")
-								.user-profile__edit-btn
-									= link_to "プロフィールを編集", edit_user_path(@user), class: 'btn btn-outline-light edit-user-btn' 
+								.right-area
+									.user-profile__msg-btn 
+										= link_to rooms_path(user_id: @user.id),method: :post, data: { turbo_method: :post }, class: "room-content__link" do 
+											i.bi.bi-envelope
+									.user-profile__edit-btn
+										= link_to "プロフィールを編集", edit_user_path(@user), class: 'btn btn-outline-light edit-user-btn' 
 						.user-profile__info-area
 							h3.user-profile__name = @user.name
 							p.user-profile__user-name = @user.username ||= "@yuuu1654"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -22,8 +22,9 @@
 									= @user.avatar_image.attached? ? image_tag(@user.avatar_image, class: "foreground-img") : image_tag('user-icon.png', class: "foreground-img")
 								.right-area
 									.user-profile__msg-btn 
-										= link_to rooms_path(user_id: @user.id),method: :post, data: { turbo_method: :post }, class: "room-content__link" do 
-											i.bi.bi-envelope
+										- if @user != current_user
+											= link_to rooms_path(user_id: @user.id),method: :post, data: { turbo_method: :post }, class: "room-content__link" do 
+												i.bi.bi-envelope
 									.user-profile__edit-btn
 										= link_to "プロフィールを編集", edit_user_path(@user), class: 'btn btn-outline-light edit-user-btn' 
 						.user-profile__info-area

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,4 +36,10 @@ Rails.application.routes.draw do
 
   # ブックマーク
   resources :bookmarks, only: %i[index create destroy]
+
+  # メッセージ
+  resources :messages, only: %i[create]
+  get '/messages', to: 'rooms#index'
+  post '/messages/:user_id', to: 'rooms#create', as: 'rooms'
+  get '/messages/:room_id', to: 'rooms#show', as: 'room_show'
 end

--- a/db/migrate/20240302062358_create_messages.rb
+++ b/db/migrate/20240302062358_create_messages.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messages do |t|
+      # usersテーブルのFKに設定 (t.referencesを使用する場合、カラム名にはidをつけない)
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      t.text :body
+
+      t.timestamps
+    end
+
+    # 自分自身にはメッセージしない仕様なので、そういった組み合わせは無いようにする
+    add_check_constraint :messages, 'sender_id != recipient_id', name: 'messages_sender_id_recipient_id_check'
+  end
+end

--- a/db/migrate/20240305070218_create_rooms.rb
+++ b/db/migrate/20240305070218_create_rooms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CreateRooms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rooms, &:timestamps
+  end
+end

--- a/db/migrate/20240305070230_add_room_id_to_messages.rb
+++ b/db/migrate/20240305070230_add_room_id_to_messages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRoomIdToMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :messages, :room, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20240305070230_add_room_id_to_messages.rb
+++ b/db/migrate/20240305070230_add_room_id_to_messages.rb
@@ -2,6 +2,6 @@
 
 class AddRoomIdToMessages < ActiveRecord::Migration[7.0]
   def change
-    add_reference :messages, :room, null: false, foreign_key: true
+    add_reference :messages, :room, foreign_key: true
   end
 end

--- a/db/migrate/20240306062038_add_user_id_to_rooms.rb
+++ b/db/migrate/20240306062038_add_user_id_to_rooms.rb
@@ -2,6 +2,6 @@
 
 class AddUserIdToRooms < ActiveRecord::Migration[7.0]
   def change
-    add_reference :rooms, :user, null: false, foreign_key: true
+    add_reference :rooms, :user, foreign_key: true
   end
 end

--- a/db/migrate/20240306062038_add_user_id_to_rooms.rb
+++ b/db/migrate/20240306062038_add_user_id_to_rooms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserIdToRooms < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :rooms, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20240315033324_remove_user_id_from_rooms.rb
+++ b/db/migrate/20240315033324_remove_user_id_from_rooms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveUserIdFromRooms < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :rooms, :user_id, :bigint
+  end
+end

--- a/db/migrate/20240315033655_create_entries.rb
+++ b/db/migrate/20240315033655_create_entries.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEntries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :entries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_062038) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "entries", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["room_id"], name: "index_entries_on_room_id"
+    t.index ["user_id"], name: "index_entries_on_user_id"
+  end
+
   create_table "follows", force: :cascade do |t|
     t.bigint "follower_id", null: false
     t.bigint "followed_id", null: false
@@ -82,6 +91,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_062038) do
     t.index ["user_id", "tweet_id"], name: "index_likes_on_user_id_and_tweet_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
+
+  create_table "messages", force: :cascade do |t|
+    t.bigint "sender_id", null: false
+    t.bigint "recipient_id", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "room_id"
+    t.index ["recipient_id"], name: "index_messages_on_recipient_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
+    t.check_constraint "sender_id <> recipient_id", name: "messages_sender_id_recipient_id_check"
+  end
   create_table "retweets", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "tweet_id", null: false
@@ -90,6 +111,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_062038) do
     t.index ["tweet_id"], name: "index_retweets_on_tweet_id"
     t.index ["user_id", "tweet_id"], name: "index_retweets_on_user_id_and_tweet_id", unique: true
     t.index ["user_id"], name: "index_retweets_on_user_id"
+  end
+
+  create_table "rooms", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -152,10 +178,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_062038) do
   add_foreign_key "bookmarks", "users"
   add_foreign_key "comments", "tweets"
   add_foreign_key "comments", "users"
+  add_foreign_key "entries", "rooms"
+  add_foreign_key "entries", "users"
   add_foreign_key "follows", "users", column: "followed_id"
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "likes", "tweets"
   add_foreign_key "likes", "users"
+  add_foreign_key "messages", "users", column: "recipient_id"
+  add_foreign_key "messages", "users", column: "sender_id"
   add_foreign_key "retweets", "tweets"
   add_foreign_key "retweets", "users"
   add_foreign_key "tweets", "users"


### PR DESCRIPTION
## 課題のリンク (テンプレ)

* https://x-clone-web.onrender.com

## やったこと

* 以下の2箇所をクリックすると、メッセージ投稿フォームへのリンクが表示されるようにしました (既存のメッセージルームがない場合は、新規作成する)
  * ツイート詳細ページ右上の3点メニュー
  * ユーザープロフィールページ右上のメッセージアイコン
* ホーム画面左側サイドバーのメッセージアイコンより、メッセージルーム一覧画面に遷移できるようにしました
  * 各メッセージルームには、最新メッセージの最初の15文字を切り取って表示しています
  * メッセージルームの名前・最新メッセージの一部をクリックするとメッセージ一覧が表示される
* メッセージ一覧表示時に、メッセージの昇順で並び替えて、一番下の最新メッセージまでスクロールするようにしました


## 動作確認方法

1. 以下のテスト用アカウントでログイン
    1. email : `test-prd01@gmail.com`
    2. password : `testprd01`
2. シークレットウィンドウで別のテスト用アカウントにログイン
    1. email : `test-prd02@gmail.com`
    2. password : `testprd02`
3. ホーム画面左側サイドバーのメッセージアイコンより、メッセージルーム一覧画面に遷移できることを確認
4. ホーム画面のツイート一覧より、[自分のツイート](https://x-clone-web.onrender.com/tweets/96)の詳細ページに遷移して、右上3点バーがないことを確認
5. 次に、ホーム画面のツイート一覧より、[他人のツイート](https://x-clone-web.onrender.com/tweets/94)の詳細ページに移動して、右上3点バーをクリックしメッセージ投稿フォームに遷移することを確認
6. また、[他人ユーザープロフィールページ](https://x-clone-web.onrender.com/users/31)のメッセージアイコンをクリックすると、メッセージ投稿フォームに遷移できることを確認
7. メッセージ送信テスト
   1. シークレットウィンドウで開いた`本番テスト用2`アカウントのホーム画面左側サイドバーより、メッセージルーム一覧に遷移後、`本番テスト用1`とのメッセージルームをクリックしてメッセージ一覧画面を表示する
   2. 7-1同様に、通常ウィンドウの`本番テスト用1`アカウントから`本番テスト用2`アカウントのメッセージ投稿フォーム画面に遷移
   3. `本番テスト用1`アカウントから`本番テスト用2`アカウントに`メッセージテスト1`とメッセージを送信し、リロードしてメッセージが反映されることを確認
   4. 7-3同様に、シークレットウィンドウ上で`本番テスト用2`アカウントから`本番テスト用1`アカウントに`メッセージテスト2`とメッセージを送信し、リロードしてメッセージが反映されることを確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
  + `rooms_controller`にて以下のコードでメッセージ相手を取得しているのですが、`where.not`で特定するのはあまり良いコードという感じがしませんでした。ですが、今回は`2人でのメッセージやりとり`という仕様で確定しているので、そのままにしています

```rb
def set_other_user
  @other_user = @room.users.where.not(id: current_user.id).first
end
```
  + 追加修正をして作業ブランチをプッシュした際に前回同様ciチェックでdangerエラーが出ていますが、一旦無視しています
  + Roomモデルで、自分と相手のエントリーに紐づくルームが存在するかを確認する処理を追加しました
    + `inner join`を使って、各結合に異なるエイリアス(e1, e2)を使って、それぞれのユーザーに対するフィルタリングを明確にしました



